### PR TITLE
fix: simplify and fix uninstall integration tests

### DIFF
--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -138,14 +138,12 @@ fn test_cx_uninstall_interactive_prompt_declined() {
     let prefix = tmp.path().join("cx-uninstall-interactive");
     std::fs::create_dir_all(prefix.join("conda-meta")).unwrap();
 
-    cx()
-        .args(["uninstall", "--prefix", prefix.to_str().unwrap()])
+    cx().args(["uninstall", "--prefix", prefix.to_str().unwrap()])
         .write_stdin("n\n")
         .assert()
         .success()
         .stderr(
-            predicate::str::contains("Continue? [y/N]")
-                .and(predicate::str::contains("Aborted.")),
+            predicate::str::contains("Continue? [y/N]").and(predicate::str::contains("Aborted.")),
         );
 
     assert!(
@@ -160,15 +158,13 @@ fn test_cx_uninstall_default_prefix_respects_home() {
     let tmp = TempDir::new().unwrap();
     std::fs::create_dir_all(tmp.path().join(".cx/conda-meta")).unwrap();
 
-    cx()
-        .env("HOME", tmp.path().as_os_str())
+    cx().env("HOME", tmp.path().as_os_str())
         .arg("uninstall")
         .write_stdin("n\n")
         .assert()
         .success()
         .stderr(
-            predicate::str::contains("Continue? [y/N]")
-                .and(predicate::str::contains("Aborted.")),
+            predicate::str::contains("Continue? [y/N]").and(predicate::str::contains("Aborted.")),
         );
 
     assert!(tmp.path().join(".cx").exists());


### PR DESCRIPTION
## Summary

- Remove redundant `test_cx_uninstall_removes_conda_meta` (duplicated coverage from `test_cx_uninstall_removes_prefix` and `test_cx_bootstrap_to_temp_prefix`, saving ~2 min CI time)
- Remove incorrect `online_tests` gate from `test_cx_uninstall_nonexistent_prefix` — no network needed, now matches the `test_cx_status_nonexistent_prefix` pattern
- Fix `test_cx_uninstall_no_prefix_argument` to use a fake `HOME` with synthetic `.cx/conda-meta` instead of depending on `~/.cx` existing on the host (was broken on CI)

## Test plan

- [x] `cargo check --tests` compiles cleanly
- [x] All 6 offline tests pass (`cargo test --test cli_integration`)
- [x] Online tests pass in CI (`cargo test --test cli_integration --features online_tests`)