### PR TITLE
fix(exec): interactive cx create and conda stdout filtering

### DIFF
--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,7 +1,7 @@
 //! Replace the current process with the installed conda binary,
 //! or run it as a subprocess with output filtering.
 
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, IsTerminal};
 use std::path::Path;
 use std::process::Stdio;
 
@@ -40,6 +40,7 @@ pub fn replace_process_with_conda(prefix: &Path, args: &[&str]) -> miette::Resul
 /// `create` and `env create` that print "conda activate" instructions.
 pub fn run_conda_filtered(prefix: &Path, args: &[&str]) -> miette::Result<()> {
     let mut child = build_command(prefix, args)?
+        .stdin(Stdio::inherit())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
         .spawn()
@@ -101,6 +102,21 @@ pub fn needs_output_filtering(args: &[&str]) -> bool {
     }
 }
 
+/// True when `create` / `env create` should use piped stdout for activation-hint filtering.
+///
+/// Conda prompts for confirmation by writing to stdout without a trailing newline, then
+/// reading stdin. If we pipe stdout and read it line-by-line, the parent blocks waiting for a
+/// newline while conda blocks on stdin, so the prompt never reaches the terminal and input
+/// looks swallowed.
+pub fn should_filter_conda_output(args: &[&str]) -> bool {
+    needs_output_filtering(args)
+        && (!std::io::stdin().is_terminal() || conda_always_yes_in_args(args))
+}
+
+fn conda_always_yes_in_args(args: &[&str]) -> bool {
+    args.iter().any(|&a| a == "-y" || a == "--yes")
+}
+
 pub(crate) fn extract_env_name(args: &[&str]) -> Option<String> {
     let mut iter = args.iter();
     while let Some(arg) = iter.next() {
@@ -155,6 +171,14 @@ mod tests {
     #[case::empty(&[], None)]
     fn test_extract_env_name(#[case] args: &[&str], #[case] expected: Option<&str>) {
         assert_eq!(extract_env_name(args), expected.map(String::from));
+    }
+
+    #[rstest]
+    #[case::no_yes_flag(&["create", "-n", "x"], false)]
+    #[case::short_y(&["create", "-y", "-n", "x"], true)]
+    #[case::long_yes(&["env", "create", "--yes", "-n", "x"], true)]
+    fn test_conda_always_yes_in_args(#[case] args: &[&str], #[case] expected: bool) {
+        assert_eq!(super::conda_always_yes_in_args(args), expected);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,7 +120,7 @@ async fn async_main() -> miette::Result<()> {
             let prefix = default_prefix()?;
             ensure_bootstrapped(&prefix).await?;
             let conda_args: Vec<&str> = raw_args[1..].iter().map(|s| s.as_str()).collect();
-            if exec::needs_output_filtering(&conda_args) {
+            if exec::should_filter_conda_output(&conda_args) {
                 return exec::run_conda_filtered(&prefix, &conda_args);
             }
             return exec::replace_process_with_conda(&prefix, &conda_args);

--- a/tests/conda_prompt_stdout_pipe_regression.rs
+++ b/tests/conda_prompt_stdout_pipe_regression.rs
@@ -1,0 +1,107 @@
+//! Regression guard for the `cx create` / `cx env create` stdout-piping bug.
+//!
+//! Conda asks for confirmation by writing a prompt to **stdout without a newline**, then
+//! calling `stdin.readline()` (see `conda/plugins/reporter_backends/console.py`). The old
+//! `cx` path piped conda stdout and consumed it with `BufRead::lines()`, which blocks until
+//! a newline. The child blocks on stdin at the same time, so the prompt never reaches the
+//! user and input appears swallowed.
+//!
+//! This test does not run the real `cx` binary; it reproduces that **conda-shaped** stdout/stdin
+//! pattern with a shell child. If someone reverts to always piping `create` on a TTY, this
+//! documents why that regresses.
+
+#[cfg(unix)]
+mod unix {
+    use std::io::{BufRead, BufReader, Write};
+    use std::process::{Command, Stdio};
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    use rstest::rstest;
+
+    /// Same sequencing as conda's console reporter: partial line on stdout, block on stdin, then
+    /// flush a newline (conda does `sys.stdout.write("\\n")` after `readline()` returns).
+    const CHILD: &str = "printf 'Proceed (y/n)? '; read _; printf '\\n'; echo after";
+
+    #[derive(Clone, Copy, Debug)]
+    enum FirstLineMode {
+        /// Matches `BufRead::read_line` usage.
+        ReadLine,
+        /// Matches `run_conda_filtered`'s `reader.lines()` loop.
+        LinesIterator,
+    }
+
+    #[rstest]
+    #[case::read_line(FirstLineMode::ReadLine)]
+    #[case::lines_iterator(FirstLineMode::LinesIterator)]
+    fn line_reader_gets_no_stdout_line_until_stdin_unblocks_child(#[case] mode: FirstLineMode) {
+        let mut child = Command::new("/bin/sh")
+            .arg("-c")
+            .arg(CHILD)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn /bin/sh");
+
+        let mut stdin = child.stdin.take().expect("child stdin");
+        let stdout = child.stdout.take().expect("child stdout");
+
+        let (tx, rx) = mpsc::channel();
+        let reader = thread::spawn(move || {
+            let start = Instant::now();
+            let mut buf = BufReader::new(stdout);
+            let line = match mode {
+                FirstLineMode::ReadLine => {
+                    let mut line = String::new();
+                    buf.read_line(&mut line)
+                        .expect("read_line from piped child stdout");
+                    line
+                }
+                FirstLineMode::LinesIterator => buf
+                    .lines()
+                    .next()
+                    .expect("lines iterator should yield")
+                    .expect("first line from piped child stdout"),
+            };
+            tx.send((start.elapsed(), line))
+                .expect("send timing + line to main thread");
+        });
+
+        const DELAY: Duration = Duration::from_millis(150);
+        thread::sleep(DELAY);
+
+        stdin
+            .write_all(b"y\n")
+            .expect("answer child's read as the user would");
+        stdin.flush().expect("flush stdin");
+
+        let (elapsed, line) = rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("reader thread should finish after stdin unblocks child");
+
+        reader.join().expect("reader thread panicked");
+
+        let status = child.wait().expect("wait child");
+        assert!(status.success(), "child should exit 0");
+
+        assert!(
+            elapsed >= DELAY.saturating_sub(Duration::from_millis(30)),
+            "line-based reader should block until stdin is answered (conda-style prompt); got {:?}",
+            elapsed
+        );
+
+        assert_eq!(
+            line.trim_end(),
+            "Proceed (y/n)?",
+            "prompt stayed buffered until stdin unblocked; first complete line is the prompt, not earlier output"
+        );
+    }
+}
+
+#[cfg(not(unix))]
+#[test]
+fn conda_prompt_stdout_pipe_pattern_skipped_on_non_unix() {
+    // The regression reproducer uses `/bin/sh`; behavior is documented in the module comment.
+}


### PR DESCRIPTION
## Summary

Fixes a deadlock-style UX bug when running `cx create` / `cx env create` from an interactive terminal: conda prints confirmation prompts to stdout without a newline, then reads stdin, while `cx` piped stdout and consumed it line-by-line.

## Changes

- Gate activation-hint filtering behind `should_filter_conda_output`: pipe only when stdin is not a TTY or `-y` / `--yes` is present; otherwise `exec` conda.
- Explicit `stdin(Stdio::inherit())` on the filtered child path.
- Integration test `tests/conda_prompt_stdout_pipe_regression.rs` (rstest: `read_line` vs `lines()`).
- Rstest cases for `conda_always_yes_in_args`.

Fixes #12.