### PR TITLE
Release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.4.1 (2026-03-30)
+
+### Fixes
+
+- **cx create / cx env create** — Avoid piping conda stdout when stdin is a TTY and `-y` / `--yes` is not set. Conda prints confirmation prompts to stdout without a trailing newline, then reads stdin; line-oriented output filtering blocked the prompt and made input appear swallowed. Activation-hint filtering still runs for non-interactive use (`-y` / `--yes`) or when stdin is not a terminal.
+- Add unix integration test reproducing conda's stdout/stdin prompt pattern (`BufRead::read_line` and `lines()`).
+
+### Tests
+
+- **Uninstall integration tests** — Use explicit `--prefix` for the interactive uninstall test on Windows (`dirs` 6 resolves home via known-folder profile, not `HOME` / `USERPROFILE`). Parametrize status vs uninstall missing-prefix cases with rstest; add a unix-only test for default prefix when `HOME` points at a synthetic layout.
+
 ## 0.4.0 (2026-03-31)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "conda-express"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "assert_cmd",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/cx-wasm"]
 
 [package]
 name = "conda-express"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 description = "A lightweight, single-binary conda bootstrapper — powered by rattler"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

Version bump and changelog for **0.4.1**, covering what landed on `main` after v0.4.0:

- Interactive `cx create` / `cx env create` stdout filtering fix (#13)
- Uninstall integration test fixes for Windows + rstest (#1)

## After merge

1. Merge this PR to `main`.
2. [Publish a GitHub Release](https://github.com/jezdez/conda-express/releases/new) for tag `v0.4.1` (draft from tag or create tag from release) so the Release workflow runs and updates `Formula/cx.rb`.