### PR TITLE
fix(docker): pre-create ~/.cx with nonroot ownership for volume mounts

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,11 @@
+# Pre-create ~/.cx owned by nonroot so Docker named volumes inherit
+# correct ownership instead of defaulting to root.
+FROM busybox:stable AS prep
+RUN mkdir -p /home/nonroot/.cx && chown 65532:65532 /home/nonroot/.cx
+
 # Pin by digest for reproducible builds (update via Renovate/Dependabot)
 FROM gcr.io/distroless/cc-debian12:nonroot@sha256:7e5b8df2f4d36f5599ef4ab856d7d444922531709becb03f3368c6d797d0a5eb
 ARG TARGETARCH
+COPY --from=prep --chown=nonroot:nonroot /home/nonroot/.cx /home/nonroot/.cx
 COPY cx-linux-${TARGETARCH} /usr/local/bin/cx
 ENTRYPOINT ["/usr/local/bin/cx"]


### PR DESCRIPTION
## Summary

- Docker named volumes default to root ownership, which causes `cx bootstrap` to fail with "Permission denied" when running as the distroless `nonroot` user (UID 65532).
- Adds a multi-stage build using `busybox:stable` to pre-create `/home/nonroot/.cx` with the correct ownership. Docker copies image directory ownership to newly created named volumes, so `cx-data` is initialized as nonroot-owned.

## Test plan

- [x] Verified locally: `docker export` confirms `/home/nonroot/.cx/` is owned by UID 65532:65532 in the built image
- [ ] `docker run --rm -v cx-data:/home/nonroot/.cx ghcr.io/jezdez/conda-express bootstrap` succeeds without permission errors