### PR TITLE
fix: precompile Python bytecode after bootstrap

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -188,17 +188,15 @@ fn compile_python_bytecode(prefix: &Path) {
         return;
     }
 
-    eprintln!(
-        "{} Compiling Python bytecode...",
-        console::style(">>").cyan().bold(),
-    );
-
-    let result = std::process::Command::new(&python)
-        .args(["-m", "compileall", "-q", "-j", "0"])
-        .arg(prefix.join("lib"))
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status();
+    let lib_dir = prefix.join("lib");
+    let result = install::wrap_spinner("compiling Python bytecode", move || {
+        std::process::Command::new(&python)
+            .args(["-m", "compileall", "-q", "-j", "0"])
+            .arg(&lib_dir)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+    });
 
     match result {
         Ok(s) if s.success() => {}

--- a/src/install.rs
+++ b/src/install.rs
@@ -36,7 +36,7 @@ static GLOBAL_MP: std::sync::LazyLock<MultiProgress> = std::sync::LazyLock::new(
     mp
 });
 
-fn multi_progress() -> MultiProgress {
+pub(crate) fn multi_progress() -> MultiProgress {
     GLOBAL_MP.clone()
 }
 
@@ -505,7 +505,7 @@ pub(crate) fn apply_excludes(
     filtered
 }
 
-fn wrap_spinner<T, F: FnOnce() -> T>(msg: impl Into<Cow<'static, str>>, func: F) -> T {
+pub(crate) fn wrap_spinner<T, F: FnOnce() -> T>(msg: impl Into<Cow<'static, str>>, func: F) -> T {
     let pb = multi_progress().add(ProgressBar::new_spinner());
     pb.enable_steady_tick(Duration::from_millis(100));
     pb.set_style(ProgressStyle::with_template("   {spinner:.green} {msg}").unwrap());


### PR DESCRIPTION
## Summary

- After Rattler installs packages, `.pyc` bytecode files don't exist yet, so the first `conda` invocation triggers compilation of every `.py` file on import, causing a noticeable startup delay.
- Adds a `compileall` step at the end of bootstrap: `python -m compileall -q -j 0 <prefix>/lib`. Uses `-j 0` for parallel compilation across all CPU cores and `-q` for quiet output.
- Shows an animated spinner during compilation, consistent with the existing "solving environment" and repodata-fetch spinners.
- Non-fatal: if compilation fails for any reason, bootstrap still succeeds with a warning.

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` — all 106 tests pass
- [ ] `cx bootstrap --force` completes with spinner visible during bytecode compilation
- [ ] First `cx info` after bootstrap starts without delay