### PR TITLE
docs: update binary size references from ~17 MB to 7-11 MB

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,7 +2,7 @@
 
 ## What is conda-express?
 
-conda-express (cx) is a lightweight, single-binary bootstrapper for conda, written in Rust using the [rattler](https://github.com/conda/rattler) crate ecosystem. It replaces the miniconda/constructor install pattern with a ~17 MB static binary that can install a fully functional conda environment in seconds.
+conda-express (cx) is a lightweight, single-binary bootstrapper for conda, written in Rust using the [rattler](https://github.com/conda/rattler) crate ecosystem. It replaces the miniconda/constructor install pattern with a 7-11 MB static binary that can install a fully functional conda environment in seconds.
 
 Inspired by uv's single-binary distribution model, cx aims to be the fastest way to get a working conda installation.
 
@@ -67,7 +67,7 @@ The project also includes **cx-wasm**, a WebAssembly build of the same rattler-b
 
 | Metric | Value |
 |---|---|
-| Release binary size | ~17 MB |
+| Release binary size | 7-11 MB |
 | Installed packages (base) | 86 |
 | Excluded packages (libmamba tree) | 27 |
 | Bootstrap time (embedded lockfile) | ~3-5 s |
@@ -90,7 +90,7 @@ pixi.toml              [tool.cx]: packages, channels, excludes
     cx.lock            rattler-lock v6 (embedded via include_str!)
        |
        v
-      cx               Single binary (~17 MB release)
+      cx               Single binary (7-11 MB release)
        |
        +---> bootstrap -----> install from lockfile (fast path)
        |                       or live solve (fallback)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A lightweight, single-binary bootstrapper for [conda](https://github.com/conda/conda), powered by [rattler](https://github.com/conda/rattler). The `cx` binary is short for **c**onda e**x**press.
 
-cx replaces the miniconda/constructor installation pattern with a ~17 MB static binary that bootstraps a fully functional conda environment in seconds.
+cx replaces the miniconda/constructor installation pattern with a 7-11 MB static binary that bootstraps a fully functional conda environment in seconds.
 
 ## Quick start
 


### PR DESCRIPTION
## Summary

- README.md and DESIGN.md still referenced ~17 MB binary size, which was the pre-optimization figure.
- Updated to 7-11 MB to match actual release binary sizes (7.1 MB macOS ARM to 10.8 MB Windows x64).
- CHANGELOG entries left as-is since they're historical records.

## Test plan

- Docs-only change, no code affected.