### PR TITLE
Embed remaining demo GIFs in docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,8 @@ This will show what will be removed and ask for confirmation. Use `--yes` to ski
 
 ## Activation model
 
+![cx delegates conda commands transparently](demos/passthrough.gif)
+
 cx ships with conda-spawn instead of traditional `conda activate`. There is no need to run `conda init` or modify shell profiles.
 
 ```bash

--- a/docs/features.md
+++ b/docs/features.md
@@ -87,6 +87,8 @@ for the full feature set.
 
 ## Frozen base prefix (CEP 22)
 
+![cx status, cx info, and cx env list](../demos/status.gif)
+
 After bootstrap, cx writes a `conda-meta/frozen` marker file per
 [CEP 22](https://conda.org/learn/ceps/cep-0022/). This protects the base
 prefix from accidental modification. Users should create named environments

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -177,6 +177,8 @@ exit    # or Ctrl+D
 
 ## Use conda normally
 
+![cx delegates conda commands transparently](../demos/passthrough.gif)
+
 All conda commands work transparently through cx:
 
 ```bash


### PR DESCRIPTION
## Summary

- Embed passthrough demo in README's Activation model section
- Embed passthrough demo in quickstart's Use conda normally section
- Embed status demo in features' Frozen base prefix section

Complements the existing demo placements (quickstart, status, passthrough, workspaces) that were added to the main docs pages in earlier commits.

## Test plan

- [x] Verify GIFs render correctly on GitHub (README)
- [x] Build docs locally and check image paths resolve