### PR TITLE
fix(jupyterlite): update yarn.lock TypeScript compat patch hash

### DIFF
--- a/cx-jupyterlite/yarn.lock
+++ b/cx-jupyterlite/yarn.lock
@@ -3386,11 +3386,11 @@ __metadata:
 
 "typescript@patch:typescript@^6.0#~builtin<compat/typescript>":
   version: 6.0.2
-  resolution: "typescript@patch:typescript@npm%3A6.0.2#~builtin<compat/typescript>::version=6.0.2&hash=5786d5"
+  resolution: "typescript@patch:typescript@npm%3A6.0.2#~builtin<compat/typescript>::version=6.0.2&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 9f29a9339aa66f5e13485c596c8d4d086fb95960f8be8a23ea6ef33afe61f7c465d330a6f77911bb8613f231c2ebf131763a82d277cefa61147b24af2073f0c4
+  checksum: 71a55653741fb12e81e7002c501ce2e5847e6cb251bc868de981561c07de178efed8f799ffc69cff92e162ceb44b67d25d60e293170db229cc5081afefababe3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Updates the TypeScript compatibility patch hash in `cx-jupyterlite/yarn.lock` from `5786d5` to `85af82`
- This hash is Yarn-version-dependent and was causing CI failures with `YN0028: The lockfile would have been modified by this install, which is explicitly forbidden`
- Fixes the "Build JupyterLite site" step in the demo CI job

## Test plan

- [x] CI demo job passes (JupyterLite build completes successfully)