### PR TITLE
Fix: stop self-deleting cx binary on uninstall (#34)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -67,6 +67,7 @@ fn main() {
     println!("cargo:rerun-if-env-changed=CX_EXCLUDE");
     println!("cargo:rerun-if-env-changed=CX_PLATFORM");
     println!("cargo:rerun-if-env-changed=CX_EMBED_PAYLOAD");
+    println!("cargo:rerun-if-env-changed=CX_INSTALL_METHOD");
 
     let embed_payload = env::var("CX_EMBED_PAYLOAD").ok().is_some_and(|v| v == "1");
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,6 +101,7 @@ For custom builds without editing `pixi.toml` (e.g. via the
 | `CX_PACKAGES` | `packages` | Comma-separated [MatchSpec](https://conda.io/projects/conda/en/latest/user-guide/concepts/pkg-specs.html) strings |
 | `CX_CHANNELS` | `channels` | Comma-separated channel names |
 | `CX_EXCLUDE` | `exclude` | Comma-separated package names |
+| `CX_INSTALL_METHOD` | *(none)* | Installation method name (e.g. `homebrew`, `cargo`). Baked into the binary; used by `cx uninstall` to show a context-aware removal hint |
 
 Empty values are ignored (the `pixi.toml` defaults are used).
 

--- a/docs/reference/installer.md
+++ b/docs/reference/installer.md
@@ -134,9 +134,12 @@ The easiest way to uninstall is the built-in command:
 cx uninstall
 ```
 
-This removes the conda prefix (including all named environments), the cx
-binary, and any PATH entries added by the installer. It will show what will
-be removed and ask for confirmation (use `--yes` to skip).
+This removes the conda prefix (including all named environments) and any
+PATH entries added by the installer. It will show what will be removed and
+ask for confirmation (use `--yes` to skip).
+
+After completion, cx prints a hint for removing the binary itself (e.g.
+`brew uninstall conda-express` for Homebrew installs).
 
 See {ref}`cx uninstall <cli-cx-uninstall>` for full details.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,7 +14,7 @@ const AFTER_HELP: &str = "\x1b[1;4mQuick start:\x1b[0m
 \x1b[1;4mManagement:\x1b[0m
 
   cx status                              Show installation details
-  cx uninstall                           Remove cx, conda, and all environments
+  cx uninstall                           Remove conda prefix and all environments
 
 \x1b[1;4mPass-through:\x1b[0m
 
@@ -127,7 +127,7 @@ pub enum Command {
         env: Option<String>,
     },
 
-    /// Uninstall cx: remove the conda prefix, environments, and optionally the cx binary
+    /// Uninstall cx: remove the conda prefix and environments
     Uninstall {
         /// Target prefix directory (default: ~/.cx)
         #[clap(long)]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -308,10 +308,6 @@ pub(crate) fn uninstall(prefix: &Path, yes: bool, verbosity: Verbosity) -> miett
             named_envs.join(", ")
         );
     }
-    if let Some(ref bin) = cx_binary {
-        eprintln!("   cx binary: {}", bin.display());
-    }
-
     if !yes {
         eprint!("\n   Continue? [y/N] ");
         let mut input = String::new();
@@ -390,19 +386,18 @@ pub(crate) fn uninstall(prefix: &Path, yes: bool, verbosity: Verbosity) -> miett
         .into_diagnostic()
         .context("failed to remove conda prefix")?;
 
-    if let Some(ref bin) = cx_binary
-        && bin.exists()
-    {
-        if verbosity != Verbosity::Quiet {
-            eprintln!(
-                "{} Removing cx binary at {}",
-                console::style(">>").cyan().bold(),
-                bin.display()
-            );
-        }
-        std::fs::remove_file(bin)
-            .into_diagnostic()
-            .context("failed to remove cx binary")?;
+    if let Some(ref bin) = cx_binary {
+        let hint = match crate::config::INSTALL_METHOD {
+            Some("homebrew") => "   brew uninstall conda-express".to_string(),
+            Some("cargo") => "   cargo uninstall conda-express".to_string(),
+            Some(method) => format!("   Installed via: {method}"),
+            None => format!("   {}", bin.display()),
+        };
+        eprintln!(
+            "\n{} To complete removal, delete the cx binary:",
+            console::style("i").blue().bold(),
+        );
+        eprintln!("{hint}");
     }
 
     remove_shell_path_entries(prefix);

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,8 @@ pub const EMBEDDED_LOCK: &str = include_str!(concat!(env!("OUT_DIR"), "/cx.lock"
 /// `CX_EMBED_PAYLOAD=1`. Empty (0 bytes) for standard `cx` builds.
 pub const EMBEDDED_PAYLOAD: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/payload.tar.zst"));
 
+pub(crate) const INSTALL_METHOD: Option<&str> = option_env!("CX_INSTALL_METHOD");
+
 /// The `pixi.toml` embedded at compile time (contains `[tool.cx]`).
 const EMBEDDED_PIXI_TOML: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/pixi.toml"));
 

--- a/tests/snapshots/cli_integration__cx_help.snap
+++ b/tests/snapshots/cli_integration__cx_help.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/cli_integration.rs
+assertion_line: 19
 expression: stdout
 ---
 cx (conda-express) is a lightweight, single-binary bootstrapper for conda.
@@ -13,7 +14,7 @@ Commands:
   bootstrap  Bootstrap a fresh conda installation into the prefix
   status     Print cx status (prefix, channels, packages, excludes)
   shell      Activate an environment via subshell (alias for conda spawn)
-  uninstall  Uninstall cx: remove the conda prefix, environments, and optionally the cx binary
+  uninstall  Uninstall cx: remove the conda prefix and environments
   help       Show this help message
 
 Options:
@@ -39,7 +40,7 @@ Quick start:
 Management:
 
   cx status                              Show installation details
-  cx uninstall                           Remove cx, conda, and all environments
+  cx uninstall                           Remove conda prefix and all environments
 
 Pass-through:
 


### PR DESCRIPTION
## Summary
- Remove binary self-deletion from `cx uninstall` on all platforms
- Add `CX_INSTALL_METHOD` compile-time env var for install-method-aware hints (e.g. "brew uninstall conda-express")
- Print a hint with the appropriate removal command instead of deleting the binary

This fixes the Windows file-lock error and respects package manager ownership on all platforms.

Fixes #34

## Test plan
- [x] Existing uninstall tests pass
- [x] `cargo clippy` and `cargo fmt` clean