### PR TITLE
Fix: clean subenvironment artifacts on uninstall (#36)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,6 +23,13 @@ const AFTER_HELP: &str = "\x1b[1;4mQuick start:\x1b[0m
 
 \x1b[4mDocs:\x1b[0m https://jezdez.github.io/conda-express/";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verbosity {
+    Normal,
+    Verbose,
+    Quiet,
+}
+
 #[derive(Debug, Parser)]
 #[clap(
     name = "cx",
@@ -36,8 +43,28 @@ const AFTER_HELP: &str = "\x1b[1;4mQuick start:\x1b[0m
     allow_external_subcommands = true,
 )]
 pub struct Cli {
+    /// Increase output detail
+    #[clap(long, short, global = true)]
+    pub verbose: bool,
+
+    /// Suppress non-essential output
+    #[clap(long, short, global = true, conflicts_with = "verbose")]
+    pub quiet: bool,
+
     #[clap(subcommand)]
     pub command: Option<Command>,
+}
+
+impl Cli {
+    pub fn verbosity(&self) -> Verbosity {
+        if self.verbose {
+            Verbosity::Verbose
+        } else if self.quiet {
+            Verbosity::Quiet
+        } else {
+            Verbosity::Normal
+        }
+    }
 }
 
 #[derive(Debug, clap::Subcommand)]
@@ -292,6 +319,42 @@ mod tests {
     fn test_parse_no_args() {
         let cli = Cli::parse_from(["cx"]);
         assert!(cli.command.is_none(), "bare `cx` should have no command");
+    }
+
+    #[test]
+    fn test_parse_verbose_flag() {
+        let cli = Cli::parse_from(["cx", "--verbose", "bootstrap"]);
+        assert_eq!(cli.verbosity(), Verbosity::Verbose);
+    }
+
+    #[test]
+    fn test_parse_quiet_flag() {
+        let cli = Cli::parse_from(["cx", "--quiet", "bootstrap"]);
+        assert_eq!(cli.verbosity(), Verbosity::Quiet);
+    }
+
+    #[test]
+    fn test_parse_short_verbose_flag() {
+        let cli = Cli::parse_from(["cx", "-v", "status"]);
+        assert_eq!(cli.verbosity(), Verbosity::Verbose);
+    }
+
+    #[test]
+    fn test_parse_short_quiet_flag() {
+        let cli = Cli::parse_from(["cx", "-q", "status"]);
+        assert_eq!(cli.verbosity(), Verbosity::Quiet);
+    }
+
+    #[test]
+    fn test_parse_no_verbosity_flags() {
+        let cli = Cli::parse_from(["cx", "bootstrap"]);
+        assert_eq!(cli.verbosity(), Verbosity::Normal);
+    }
+
+    #[test]
+    fn test_verbose_quiet_conflict() {
+        let result = Cli::try_parse_from(["cx", "--verbose", "--quiet", "bootstrap"]);
+        assert!(result.is_err(), "--verbose and --quiet should conflict");
     }
 
     #[rstest]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,11 +1,12 @@
 //! Subcommand implementations and prefix helpers.
 
+use std::process::Stdio;
 use std::{env, path::Path};
 
 use miette::{Context, IntoDiagnostic};
 use rattler_conda_types::PrefixRecord;
 
-use crate::cli::LockSource;
+use crate::cli::{LockSource, Verbosity};
 use crate::config::{
     EMBEDDED_LOCK, embedded_config, read_metadata, write_condarc, write_frozen, write_metadata,
 };
@@ -37,6 +38,7 @@ pub(crate) async fn ensure_bootstrapped(prefix: &Path) -> miette::Result<()> {
             LockSource::Embedded,
             None,
             false,
+            Verbosity::Quiet,
         )
         .await?;
     }
@@ -74,6 +76,7 @@ pub(crate) async fn bootstrap(
     lock_source: LockSource,
     payload: Option<std::path::PathBuf>,
     offline: bool,
+    verbosity: Verbosity,
 ) -> miette::Result<()> {
     if is_bootstrapped(prefix) && !force {
         eprintln!(
@@ -101,24 +104,28 @@ pub(crate) async fn bootstrap(
         specs.extend(extra);
     }
 
-    eprintln!(
-        "{} Bootstrapping conda into {}",
-        console::style(">>").cyan().bold(),
-        prefix.display()
-    );
-    eprintln!("   Channels: {}", channels.join(", "));
-    eprintln!("   Packages: {}", specs.join(", "));
-    if !excludes.is_empty() {
-        eprintln!("   Exclude:  {}", excludes.join(", "));
-    }
-    if offline {
-        eprintln!("   Mode:     offline");
+    if verbosity != Verbosity::Quiet {
+        eprintln!(
+            "{} Bootstrapping conda into {}",
+            console::style(">>").cyan().bold(),
+            prefix.display()
+        );
+        eprintln!("   Channels: {}", channels.join(", "));
+        eprintln!("   Packages: {}", specs.join(", "));
+        if !excludes.is_empty() {
+            eprintln!("   Exclude:  {}", excludes.join(", "));
+        }
+        if offline {
+            eprintln!("   Mode:     offline");
+        }
     }
 
     let lock_content = match &lock_source {
         LockSource::Embedded => {
             if !EMBEDDED_LOCK.is_empty() {
-                eprintln!("   Using embedded lockfile");
+                if verbosity != Verbosity::Quiet {
+                    eprintln!("   Using embedded lockfile");
+                }
                 Some(EMBEDDED_LOCK.to_string())
             } else {
                 None
@@ -128,11 +135,15 @@ pub(crate) async fn bootstrap(
             let content = std::fs::read_to_string(path)
                 .into_diagnostic()
                 .context("failed to read lockfile")?;
-            eprintln!("   Using lockfile: {}", path.display());
+            if verbosity != Verbosity::Quiet {
+                eprintln!("   Using lockfile: {}", path.display());
+            }
             Some(content)
         }
         LockSource::None => {
-            eprintln!("   Live solve (lockfile disabled)");
+            if verbosity != Verbosity::Quiet {
+                eprintln!("   Live solve (lockfile disabled)");
+            }
             None
         }
     };
@@ -141,13 +152,17 @@ pub(crate) async fn bootstrap(
         let content = lock_content.ok_or_else(|| {
             miette::miette!("--payload requires a lockfile (embedded or --lockfile)")
         })?;
-        eprintln!("   Payload:  {}", payload_dir.display());
+        if verbosity != Verbosity::Quiet {
+            eprintln!("   Payload:  {}", payload_dir.display());
+        }
         install::from_lockfile_with_payload(prefix, &content, excludes, payload_dir, offline)
             .await?;
     } else if let Some(embedded_dir) = install::extract_embedded_payload()? {
         let content =
             lock_content.ok_or_else(|| miette::miette!("embedded payload requires a lockfile"))?;
-        eprintln!("   Payload:  embedded");
+        if verbosity != Verbosity::Quiet {
+            eprintln!("   Payload:  embedded");
+        }
         let result =
             install::from_lockfile_with_payload(prefix, &content, excludes, &embedded_dir, true)
                 .await;
@@ -171,13 +186,15 @@ pub(crate) async fn bootstrap(
 
     compile_python_bytecode(prefix);
 
-    eprintln!(
-        "\n{} conda bootstrapped successfully!",
-        console::style("✔").green().bold()
-    );
-    eprintln!("   Prefix: {}", prefix.display());
-    eprintln!("   Run `cx status` for details.");
-    eprintln!("   Use `cx <conda-args>` to run conda commands.");
+    if verbosity != Verbosity::Quiet {
+        eprintln!(
+            "\n{} conda bootstrapped successfully!",
+            console::style("✔").green().bold()
+        );
+        eprintln!("   Prefix: {}", prefix.display());
+        eprintln!("   Run `cx status` for details.");
+        eprintln!("   Use `cx <conda-args>` to run conda commands.");
+    }
 
     Ok(())
 }
@@ -249,7 +266,7 @@ pub(crate) fn status(prefix: &Path) -> miette::Result<()> {
     Ok(())
 }
 
-pub(crate) fn uninstall(prefix: &Path, yes: bool) -> miette::Result<()> {
+pub(crate) fn uninstall(prefix: &Path, yes: bool, verbosity: Verbosity) -> miette::Result<()> {
     if !is_bootstrapped(prefix) {
         eprintln!(
             "{} No conda installation found at {}",
@@ -308,11 +325,67 @@ pub(crate) fn uninstall(prefix: &Path, yes: bool) -> miette::Result<()> {
         }
     }
 
-    eprintln!(
-        "\n{} Removing conda prefix at {}",
-        console::style(">>").cyan().bold(),
-        prefix.display()
-    );
+    if !named_envs.is_empty() {
+        let conda = crate::exec::conda_binary(prefix);
+        for env_name in &named_envs {
+            if verbosity != Verbosity::Quiet {
+                eprintln!(
+                    "{} Removing environment: {}",
+                    console::style(">>").cyan().bold(),
+                    env_name
+                );
+            }
+            let output = std::process::Command::new(&conda)
+                .args(["remove", "--all", "-n", env_name, "-y", "--json"])
+                .env("CONDA_ROOT_PREFIX", prefix)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::null())
+                .output();
+            match output {
+                Ok(out) if out.status.success() => {
+                    if verbosity == Verbosity::Verbose
+                        && let Ok(json) = serde_json::from_slice::<serde_json::Value>(&out.stdout)
+                        && let Some(actions) = json
+                            .get("actions")
+                            .and_then(|a| a.get("UNLINK"))
+                            .and_then(|u| u.as_array())
+                    {
+                        for pkg in actions {
+                            if let Some(name) = pkg.get("name").and_then(|n| n.as_str()) {
+                                let version =
+                                    pkg.get("version").and_then(|v| v.as_str()).unwrap_or("?");
+                                eprintln!("     - {name} {version}");
+                            }
+                        }
+                    }
+                }
+                Ok(out) => {
+                    eprintln!(
+                        "{} conda exited with {} for {} (will force-remove with prefix)",
+                        console::style("!").yellow().bold(),
+                        out.status,
+                        env_name
+                    );
+                }
+                Err(e) => {
+                    eprintln!(
+                        "{} Failed to run conda for {}: {} (will force-remove with prefix)",
+                        console::style("!").yellow().bold(),
+                        env_name,
+                        e
+                    );
+                }
+            }
+        }
+    }
+
+    if verbosity != Verbosity::Quiet {
+        eprintln!(
+            "\n{} Removing conda prefix at {}",
+            console::style(">>").cyan().bold(),
+            prefix.display()
+        );
+    }
     std::fs::remove_dir_all(prefix)
         .into_diagnostic()
         .context("failed to remove conda prefix")?;
@@ -320,11 +393,13 @@ pub(crate) fn uninstall(prefix: &Path, yes: bool) -> miette::Result<()> {
     if let Some(ref bin) = cx_binary
         && bin.exists()
     {
-        eprintln!(
-            "{} Removing cx binary at {}",
-            console::style(">>").cyan().bold(),
-            bin.display()
-        );
+        if verbosity != Verbosity::Quiet {
+            eprintln!(
+                "{} Removing cx binary at {}",
+                console::style(">>").cyan().bold(),
+                bin.display()
+            );
+        }
         std::fs::remove_file(bin)
             .into_diagnostic()
             .context("failed to remove cx binary")?;
@@ -332,10 +407,12 @@ pub(crate) fn uninstall(prefix: &Path, yes: bool) -> miette::Result<()> {
 
     remove_shell_path_entries(prefix);
 
-    eprintln!(
-        "\n{} cx has been uninstalled.",
-        console::style("✔").green().bold()
-    );
+    if verbosity != Verbosity::Quiet {
+        eprintln!(
+            "\n{} cx has been uninstalled.",
+            console::style("✔").green().bold()
+        );
+    }
 
     Ok(())
 }
@@ -508,7 +585,7 @@ mod tests {
     #[test]
     fn test_uninstall_not_bootstrapped() {
         let tmp = TempDir::new().unwrap();
-        let result = uninstall(tmp.path(), true);
+        let result = uninstall(tmp.path(), true, Verbosity::Normal);
         assert!(
             result.is_ok(),
             "uninstall on empty prefix should succeed with a no-op"

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,7 @@ async fn async_main() -> miette::Result<()> {
         Some("bootstrap") | Some("status") | Some("shell") | Some("uninstall") | Some("help")
         | Some("--help") | Some("-h") | Some("--version") | Some("-V") | None => {
             let cli = Cli::parse();
+            let verbosity = cli.verbosity();
             match cli.command {
                 Some(Command::Bootstrap {
                     force,
@@ -100,6 +101,7 @@ async fn async_main() -> miette::Result<()> {
                         lock_source,
                         payload,
                         offline,
+                        verbosity,
                     )
                     .await;
                 }
@@ -109,7 +111,7 @@ async fn async_main() -> miette::Result<()> {
                 }
                 Some(Command::Uninstall { prefix, yes }) => {
                     let prefix = prefix.map(Ok).unwrap_or_else(default_prefix)?;
-                    return uninstall(&prefix, yes);
+                    return uninstall(&prefix, yes, verbosity);
                 }
                 Some(Command::Shell { env }) => {
                     let prefix = default_prefix()?;

--- a/tests/snapshots/cli_integration__cx_help.snap
+++ b/tests/snapshots/cli_integration__cx_help.snap
@@ -7,7 +7,7 @@ cx (conda-express) is a lightweight, single-binary bootstrapper for conda.
 It installs a minimal conda environment from an embedded lockfile in seconds,
 uses conda-rattler-solver instead of libmamba, and conda-spawn for activation.
 
-Usage: cx [COMMAND]
+Usage: cx [OPTIONS] [COMMAND]
 
 Commands:
   bootstrap  Bootstrap a fresh conda installation into the prefix
@@ -17,6 +17,12 @@ Commands:
   help       Show this help message
 
 Options:
+  -v, --verbose
+          Increase output detail
+
+  -q, --quiet
+          Suppress non-essential output
+
   -h, --help
           Print help (see a summary with '-h')
 


### PR DESCRIPTION
## Summary
- Before `remove_dir_all(prefix)`, run `conda remove --all -n <name> -y --json` for each named subenvironment
- This properly runs conda's unlink hooks (menuinst shortcut removal, pre-unlink scripts) and deregisters environments from `~/.conda/environments.txt`
- In verbose mode (`-v`), parse the JSON output and list each unlinked package
- Includes global `--verbose`/`--quiet` flags (prerequisite for the verbose output)

Fixes #36

## Test plan
- [x] Existing uninstall tests pass with updated signatures
- [x] `cargo clippy` and `cargo fmt` clean