### PR TITLE
Add global --verbose/-v and --quiet/-q flags

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,6 +23,13 @@ const AFTER_HELP: &str = "\x1b[1;4mQuick start:\x1b[0m
 
 \x1b[4mDocs:\x1b[0m https://jezdez.github.io/conda-express/";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verbosity {
+    Normal,
+    Verbose,
+    Quiet,
+}
+
 #[derive(Debug, Parser)]
 #[clap(
     name = "cx",
@@ -36,8 +43,28 @@ const AFTER_HELP: &str = "\x1b[1;4mQuick start:\x1b[0m
     allow_external_subcommands = true,
 )]
 pub struct Cli {
+    /// Increase output detail
+    #[clap(long, short, global = true)]
+    pub verbose: bool,
+
+    /// Suppress non-essential output
+    #[clap(long, short, global = true, conflicts_with = "verbose")]
+    pub quiet: bool,
+
     #[clap(subcommand)]
     pub command: Option<Command>,
+}
+
+impl Cli {
+    pub fn verbosity(&self) -> Verbosity {
+        if self.verbose {
+            Verbosity::Verbose
+        } else if self.quiet {
+            Verbosity::Quiet
+        } else {
+            Verbosity::Normal
+        }
+    }
 }
 
 #[derive(Debug, clap::Subcommand)]
@@ -317,5 +344,33 @@ mod tests {
             }
             other => panic!("expected Bootstrap, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_parse_verbose_bootstrap() {
+        let cli = Cli::parse_from(["cx", "-v", "bootstrap"]);
+        assert!(cli.verbose);
+        assert!(!cli.quiet);
+        assert_matches!(cli.command, Some(Command::Bootstrap { .. }));
+    }
+
+    #[test]
+    fn test_parse_quiet_uninstall() {
+        let cli = Cli::parse_from(["cx", "-q", "uninstall", "--yes"]);
+        assert!(!cli.verbose);
+        assert!(cli.quiet);
+        assert_matches!(cli.command, Some(Command::Uninstall { yes: true, .. }));
+    }
+
+    #[test]
+    fn test_verbosity_method() {
+        let cli = Cli::parse_from(["cx", "bootstrap"]);
+        assert_eq!(cli.verbosity(), Verbosity::Normal);
+
+        let cli = Cli::parse_from(["cx", "-v", "bootstrap"]);
+        assert_eq!(cli.verbosity(), Verbosity::Verbose);
+
+        let cli = Cli::parse_from(["cx", "-q", "bootstrap"]);
+        assert_eq!(cli.verbosity(), Verbosity::Quiet);
     }
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -5,7 +5,7 @@ use std::{env, path::Path};
 use miette::{Context, IntoDiagnostic};
 use rattler_conda_types::PrefixRecord;
 
-use crate::cli::LockSource;
+use crate::cli::{LockSource, Verbosity};
 use crate::config::{
     EMBEDDED_LOCK, embedded_config, read_metadata, write_condarc, write_frozen, write_metadata,
 };
@@ -37,6 +37,7 @@ pub(crate) async fn ensure_bootstrapped(prefix: &Path) -> miette::Result<()> {
             LockSource::Embedded,
             None,
             false,
+            Verbosity::Quiet,
         )
         .await?;
     }
@@ -74,7 +75,10 @@ pub(crate) async fn bootstrap(
     lock_source: LockSource,
     payload: Option<std::path::PathBuf>,
     offline: bool,
+    verbosity: Verbosity,
 ) -> miette::Result<()> {
+    let quiet = verbosity == Verbosity::Quiet;
+
     if is_bootstrapped(prefix) && !force {
         eprintln!(
             "{} conda is already bootstrapped at {}",
@@ -101,24 +105,28 @@ pub(crate) async fn bootstrap(
         specs.extend(extra);
     }
 
-    eprintln!(
-        "{} Bootstrapping conda into {}",
-        console::style(">>").cyan().bold(),
-        prefix.display()
-    );
-    eprintln!("   Channels: {}", channels.join(", "));
-    eprintln!("   Packages: {}", specs.join(", "));
-    if !excludes.is_empty() {
-        eprintln!("   Exclude:  {}", excludes.join(", "));
-    }
-    if offline {
-        eprintln!("   Mode:     offline");
+    if !quiet {
+        eprintln!(
+            "{} Bootstrapping conda into {}",
+            console::style(">>").cyan().bold(),
+            prefix.display()
+        );
+        eprintln!("   Channels: {}", channels.join(", "));
+        eprintln!("   Packages: {}", specs.join(", "));
+        if !excludes.is_empty() {
+            eprintln!("   Exclude:  {}", excludes.join(", "));
+        }
+        if offline {
+            eprintln!("   Mode:     offline");
+        }
     }
 
     let lock_content = match &lock_source {
         LockSource::Embedded => {
             if !EMBEDDED_LOCK.is_empty() {
-                eprintln!("   Using embedded lockfile");
+                if !quiet {
+                    eprintln!("   Using embedded lockfile");
+                }
                 Some(EMBEDDED_LOCK.to_string())
             } else {
                 None
@@ -128,11 +136,15 @@ pub(crate) async fn bootstrap(
             let content = std::fs::read_to_string(path)
                 .into_diagnostic()
                 .context("failed to read lockfile")?;
-            eprintln!("   Using lockfile: {}", path.display());
+            if !quiet {
+                eprintln!("   Using lockfile: {}", path.display());
+            }
             Some(content)
         }
         LockSource::None => {
-            eprintln!("   Live solve (lockfile disabled)");
+            if !quiet {
+                eprintln!("   Live solve (lockfile disabled)");
+            }
             None
         }
     };
@@ -141,13 +153,17 @@ pub(crate) async fn bootstrap(
         let content = lock_content.ok_or_else(|| {
             miette::miette!("--payload requires a lockfile (embedded or --lockfile)")
         })?;
-        eprintln!("   Payload:  {}", payload_dir.display());
+        if !quiet {
+            eprintln!("   Payload:  {}", payload_dir.display());
+        }
         install::from_lockfile_with_payload(prefix, &content, excludes, payload_dir, offline)
             .await?;
     } else if let Some(embedded_dir) = install::extract_embedded_payload()? {
         let content =
             lock_content.ok_or_else(|| miette::miette!("embedded payload requires a lockfile"))?;
-        eprintln!("   Payload:  embedded");
+        if !quiet {
+            eprintln!("   Payload:  embedded");
+        }
         let result =
             install::from_lockfile_with_payload(prefix, &content, excludes, &embedded_dir, true)
                 .await;
@@ -171,13 +187,15 @@ pub(crate) async fn bootstrap(
 
     compile_python_bytecode(prefix);
 
-    eprintln!(
-        "\n{} conda bootstrapped successfully!",
-        console::style("✔").green().bold()
-    );
-    eprintln!("   Prefix: {}", prefix.display());
-    eprintln!("   Run `cx status` for details.");
-    eprintln!("   Use `cx <conda-args>` to run conda commands.");
+    if !quiet {
+        eprintln!(
+            "\n{} conda bootstrapped successfully!",
+            console::style("✔").green().bold()
+        );
+        eprintln!("   Prefix: {}", prefix.display());
+        eprintln!("   Run `cx status` for details.");
+        eprintln!("   Use `cx <conda-args>` to run conda commands.");
+    }
 
     Ok(())
 }
@@ -249,7 +267,9 @@ pub(crate) fn status(prefix: &Path) -> miette::Result<()> {
     Ok(())
 }
 
-pub(crate) fn uninstall(prefix: &Path, yes: bool) -> miette::Result<()> {
+pub(crate) fn uninstall(prefix: &Path, yes: bool, verbosity: Verbosity) -> miette::Result<()> {
+    let quiet = verbosity == Verbosity::Quiet;
+
     if !is_bootstrapped(prefix) {
         eprintln!(
             "{} No conda installation found at {}",
@@ -308,11 +328,13 @@ pub(crate) fn uninstall(prefix: &Path, yes: bool) -> miette::Result<()> {
         }
     }
 
-    eprintln!(
-        "\n{} Removing conda prefix at {}",
-        console::style(">>").cyan().bold(),
-        prefix.display()
-    );
+    if !quiet {
+        eprintln!(
+            "\n{} Removing conda prefix at {}",
+            console::style(">>").cyan().bold(),
+            prefix.display()
+        );
+    }
     std::fs::remove_dir_all(prefix)
         .into_diagnostic()
         .context("failed to remove conda prefix")?;
@@ -320,17 +342,19 @@ pub(crate) fn uninstall(prefix: &Path, yes: bool) -> miette::Result<()> {
     if let Some(ref bin) = cx_binary
         && bin.exists()
     {
-        eprintln!(
-            "{} Removing cx binary at {}",
-            console::style(">>").cyan().bold(),
-            bin.display()
-        );
+        if !quiet {
+            eprintln!(
+                "{} Removing cx binary at {}",
+                console::style(">>").cyan().bold(),
+                bin.display()
+            );
+        }
         std::fs::remove_file(bin)
             .into_diagnostic()
             .context("failed to remove cx binary")?;
     }
 
-    remove_shell_path_entries(prefix);
+    remove_shell_path_entries(prefix, quiet);
 
     eprintln!(
         "\n{} cx has been uninstalled.",
@@ -340,7 +364,7 @@ pub(crate) fn uninstall(prefix: &Path, yes: bool) -> miette::Result<()> {
     Ok(())
 }
 
-fn remove_shell_path_entries(prefix: &Path) {
+fn remove_shell_path_entries(prefix: &Path, quiet: bool) {
     let condabin_path = format!("export PATH=\"{}/condabin:$PATH\"", prefix.display());
     let install_dir = env::current_exe()
         .ok()
@@ -360,13 +384,14 @@ fn remove_shell_path_entries(prefix: &Path) {
         home.join(".config/fish/config.fish"),
     ];
 
-    clean_path_entries_from_profiles(&profiles, &condabin_path, install_path.as_deref());
+    clean_path_entries_from_profiles(&profiles, &condabin_path, install_path.as_deref(), quiet);
 }
 
 pub(crate) fn clean_path_entries_from_profiles(
     profiles: &[std::path::PathBuf],
     condabin_path: &str,
     install_path: Option<&str>,
+    quiet: bool,
 ) {
     for profile in profiles {
         if !profile.exists() {
@@ -391,7 +416,7 @@ pub(crate) fn clean_path_entries_from_profiles(
 
         if changed {
             let new_contents = filtered.join("\n");
-            if std::fs::write(profile, &new_contents).is_ok() {
+            if std::fs::write(profile, &new_contents).is_ok() && !quiet {
                 eprintln!(
                     "{} Cleaned PATH entry from {}",
                     console::style(">>").cyan().bold(),
@@ -444,6 +469,7 @@ pub(crate) fn print_disabled_init() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::Verbosity;
     use rstest::rstest;
     use tempfile::TempDir;
 
@@ -508,7 +534,7 @@ mod tests {
     #[test]
     fn test_uninstall_not_bootstrapped() {
         let tmp = TempDir::new().unwrap();
-        let result = uninstall(tmp.path(), true);
+        let result = uninstall(tmp.path(), true, Verbosity::Normal);
         assert!(
             result.is_ok(),
             "uninstall on empty prefix should succeed with a no-op"
@@ -526,7 +552,7 @@ mod tests {
         )
         .unwrap();
 
-        clean_path_entries_from_profiles(std::slice::from_ref(&bashrc), condabin_line, None);
+        clean_path_entries_from_profiles(std::slice::from_ref(&bashrc), condabin_line, None, false);
 
         let result = std::fs::read_to_string(&bashrc).unwrap();
         assert!(
@@ -554,6 +580,7 @@ mod tests {
             std::slice::from_ref(&zshrc),
             "export PATH=\"/unused/condabin:$PATH\"",
             Some(install_line),
+            false,
         );
 
         let result = std::fs::read_to_string(&zshrc).unwrap();
@@ -571,7 +598,7 @@ mod tests {
     fn test_clean_path_entries_skips_missing_profiles() {
         let tmp = TempDir::new().unwrap();
         let missing = tmp.path().join("nonexistent");
-        clean_path_entries_from_profiles(&[missing], "whatever", None);
+        clean_path_entries_from_profiles(&[missing], "whatever", None, false);
     }
 
     #[test]
@@ -585,6 +612,7 @@ mod tests {
             std::slice::from_ref(&bashrc),
             "export PATH=\"/not/present:$PATH\"",
             None,
+            false,
         );
 
         let result = std::fs::read_to_string(&bashrc).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,7 @@ async fn async_main() -> miette::Result<()> {
         Some("bootstrap") | Some("status") | Some("shell") | Some("uninstall") | Some("help")
         | Some("--help") | Some("-h") | Some("--version") | Some("-V") | None => {
             let cli = Cli::parse();
+            let verbosity = cli.verbosity();
             match cli.command {
                 Some(Command::Bootstrap {
                     force,
@@ -100,6 +101,7 @@ async fn async_main() -> miette::Result<()> {
                         lock_source,
                         payload,
                         offline,
+                        verbosity,
                     )
                     .await;
                 }
@@ -109,7 +111,7 @@ async fn async_main() -> miette::Result<()> {
                 }
                 Some(Command::Uninstall { prefix, yes }) => {
                     let prefix = prefix.map(Ok).unwrap_or_else(default_prefix)?;
-                    return uninstall(&prefix, yes);
+                    return uninstall(&prefix, yes, verbosity);
                 }
                 Some(Command::Shell { env }) => {
                     let prefix = default_prefix()?;

--- a/tests/snapshots/cli_integration__cx_help.snap
+++ b/tests/snapshots/cli_integration__cx_help.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/cli_integration.rs
+assertion_line: 19
 expression: stdout
 ---
 cx (conda-express) is a lightweight, single-binary bootstrapper for conda.
@@ -7,7 +8,7 @@ cx (conda-express) is a lightweight, single-binary bootstrapper for conda.
 It installs a minimal conda environment from an embedded lockfile in seconds,
 uses conda-rattler-solver instead of libmamba, and conda-spawn for activation.
 
-Usage: cx [COMMAND]
+Usage: cx [OPTIONS] [COMMAND]
 
 Commands:
   bootstrap  Bootstrap a fresh conda installation into the prefix
@@ -17,6 +18,12 @@ Commands:
   help       Show this help message
 
 Options:
+  -v, --verbose
+          Increase output detail
+
+  -q, --quiet
+          Suppress non-essential output
+
   -h, --help
           Print help (see a summary with '-h')
 


### PR DESCRIPTION
## Summary
- Add `Verbosity` enum (`Normal`, `Verbose`, `Quiet`) and global `--verbose`/`-v` and `--quiet`/`-q` flags to the top-level `Cli` struct
- Thread verbosity through `bootstrap()` and `uninstall()` commands
- Quiet mode suppresses progress banners in `bootstrap()` and progress lines in `uninstall()`
- Auto-bootstrap via `ensure_bootstrapped()` uses quiet mode

## Test plan
- [x] New CLI parsing tests for `-v`, `-q`, and `verbosity()` method
- [x] Existing tests updated to pass `Verbosity::Normal`
- [x] `cargo clippy` and `cargo fmt` clean