### PR TITLE
fix(wasm): fix WASM and demo builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ name = "cx-wasm"
 version = "0.1.0"
 dependencies = [
  "bzip2-rs",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "js-sys",
  "rattler_conda_types",
  "rattler_lock",
@@ -2241,18 +2241,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/cx-wasm/Cargo.toml
+++ b/crates/cx-wasm/Cargo.toml
@@ -39,7 +39,7 @@ serde-wasm-bindgen = "0.6"
 serde_bytes = "0.11"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.4", features = ["wasm_js"] }
+getrandom = { version = "0.3", features = ["wasm_js"] }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/cx-jupyterlite/yarn.lock
+++ b/cx-jupyterlite/yarn.lock
@@ -3400,11 +3400,11 @@ __metadata:
 
 "typescript@patch:typescript@^6.0#~builtin<compat/typescript>":
   version: 6.0.3
-  resolution: "typescript@patch:typescript@npm%3A6.0.3#~builtin<compat/typescript>::version=6.0.3&hash=5786d5"
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#~builtin<compat/typescript>::version=6.0.3&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 238430fdcadd2ca8ec7179bc644b324dbe4d13d647efae95351f216c7d9645092c0d848a45bd5a27a3d9058e2466eb8d67f9d944e2a78fa32171eee2e2f8d11e
+  checksum: 8ed159a81ab4901a620c19fda539632cee610f8ec34dde57a3acc6b6df72894ad0b50bdd1946b763313d9b73dedb019d2e81c03eff06c0f2c785cde30a537d15
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- The WASM build (`cx-wasm`) broke because `ahash` 0.8.12 pulls in `getrandom` 0.3.x, which requires the `wasm_js` feature on `wasm32` targets. The previous direct dependency on `getrandom` 0.4 was unused by any transitive dep and didn't cover the 0.3.x version that actually needed the feature flag. Downgrade the direct dependency from 0.4 to 0.3 so the feature is applied where it's needed.
- The demo CI job (`jlpm install`) was failing because the Yarn built-in compat patch for TypeScript 6.0.3 changed its hash. Regenerate `cx-jupyterlite/yarn.lock` to pick up the new hash.

## Test plan

- WASM build in the Docs & Demo workflow should pass again
- `cargo tree -p cx-wasm --target wasm32-unknown-unknown -i getrandom@0.3.4` confirms `cx-wasm` is now a direct dependent
- The demo job should pass now that `yarn.lock` matches the current Yarn compat patches