### PR TITLE
docs: update package lists, version pins, and file structure

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -280,13 +280,13 @@ The Web Worker demo (`crates/cx-wasm/www/conda-test.html`) uses Comlink for RPC 
 conda-express/
   Cargo.toml            Rust project manifest (crate: conda-express, binary: cx)
   pyproject.toml        maturin config for PyPI wheel builds
-  pixi.toml             Dev environment + [tool.cx] config + feature envs
+  pixi.toml             Dev environment + [tool.cx] config + [feature.cx-env] + pixi tasks
   action.yml            Composite GitHub Action for building custom cx binaries
   Formula/cx.rb         Homebrew formula (same-repo tap)
-  pixi.lock             Locked dev dependencies
+  pixi.lock             Locked dev + cx-env dependencies
   build.rs              Compile-time solver and lockfile generator
-  cx.lock               Cached rattler-lock v6 lockfile (checked in)
-  cx.lock.hash          Config hash for cx.lock cache invalidation
+  cx.lock               rattler-lock v6 lockfile extracted from pixi.lock (checked in)
+  cx.lock.hash          Content hash of pixi.lock + pixi.toml for cache invalidation
   CHANGELOG.md          Release changelog
   LICENSE               BSD 3-Clause
   README.md             User-facing documentation
@@ -301,6 +301,11 @@ conda-express/
     exec.rs             Process replacement (exec into installed conda)
     commands.rs         Bootstrap, status, uninstall implementations
     exclude.rs          Post-solve package exclusion algorithm
+
+  crates/xtask/         Internal build tools (cx-build)
+    Cargo.toml          Workspace member (rattler_lock, clap)
+    src/
+      main.rs           cx-build lock: extracts cx.lock from pixi.lock's cx-env environment
 
   crates/cx-wasm/       cx-wasm WASM crate
     Cargo.toml          Workspace member (rattler, wasm-bindgen, web-sys)
@@ -413,6 +418,7 @@ packages = [
     "conda-spawn",
     "conda-pypi",
     "conda-self",
+    "conda-workspaces",
 ]
 exclude = ["conda-libmamba-solver"]
 ```
@@ -460,12 +466,7 @@ Default prefix: `~/.cx`
 | conda-spawn | Subprocess-based activation (replaces `conda activate`) |
 | conda-pypi | PyPI interoperability (install, solve, convert) |
 | conda-self | Base environment self-management |
-
-### Planned additions
-
-| Plugin | Purpose | Blocker |
-|---|---|---|
-| [conda-workspaces](https://github.com/conda-incubator/conda-workspaces) | Multi-environment workspace management (`conda workspace`, `cw`) | Needs conda-forge feedstock (dep: conda-lockfiles is already on conda-forge) |
+| [conda-workspaces](https://conda-incubator.github.io/conda-workspaces/) | Multi-environment workspace and task management |
 
 ## Lockfile compatibility
 
@@ -501,7 +502,7 @@ cx is published to PyPI as platform wheels via [maturin](https://github.com/PyO3
 
 All workflows use `pixi` for toolchain management:
 
-- **`ci.yml`** — runs on push to `main` and PRs. Builds and tests across 5 targets (linux-x64, linux-aarch64, macos-x64, macos-arm64, windows-x64). Uploads canary binaries as artifacts. Runs `pixi run lint` separately.
+- **`ci.yml`** — runs on push to `main` and PRs. Builds and tests across 5 targets (linux-x64, linux-aarch64, macos-x64, macos-arm64, windows-x64). Uploads canary binaries as artifacts. Runs `pixi run lint` separately. Uses `sccache` for Rust compilation caching.
 - **`release.yml`** — triggers on tag push (`v*`). Orchestrates the full release pipeline: builds native binaries, builds maturin platform wheels and sdist, creates a GitHub Release with binary assets, publishes wheels to PyPI via trusted publishing (OIDC), and publishes the crate to crates.io via trusted publishing (`rust-lang/crates-io-auth-action`). All steps run as separate jobs with dependency ordering.
 - **`build.yml`** — reusable workflow (`workflow_call`) for building custom cx binaries. Accepts `packages`, `channels`, `exclude`, and `ref` inputs. Builds all 5 platforms using the composite action and uploads binary artifacts with checksums.
 - **`docs.yml`** — triggers on push to `main` and PRs (docs, lite, cx-wasm, conda-emscripten, recipes paths). Builds Sphinx documentation and JupyterLite demo (cx-wasm WASM build + conda recipes + `lite/build.py`). Deploys docs to GitHub Pages root and demo to `/demo/` subdirectory.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -284,9 +284,9 @@ conda-express/
   action.yml            Composite GitHub Action for building custom cx binaries
   Formula/cx.rb         Homebrew formula (same-repo tap)
   pixi.lock             Locked dev + cx-env dependencies
-  build.rs              Compile-time solver and lockfile generator
+  build.rs              Copies cx.lock (and optional payload.tar.zst) into OUT_DIR for embedding
   cx.lock               rattler-lock v6 lockfile extracted from pixi.lock (checked in)
-  cx.lock.hash          Content hash of pixi.lock + pixi.toml for cache invalidation
+  cx.lock.hash          SHA-256 of pixi.toml for cx.lock cache invalidation
   CHANGELOG.md          Release changelog
   LICENSE               BSD 3-Clause
   README.md             User-facing documentation
@@ -300,12 +300,15 @@ conda-express/
     install.rs          Package installation (lockfile + live-solve paths)
     exec.rs             Process replacement (exec into installed conda)
     commands.rs         Bootstrap, status, uninstall implementations
-    exclude.rs          Post-solve package exclusion algorithm
 
-  crates/xtask/         Internal build tools (cx-build)
-    Cargo.toml          Workspace member (rattler_lock, clap)
+  crates/cx-build/      Internal build tools (binary: cx-build)
+    Cargo.toml          Workspace member (clap, rattler_lock, rattler_conda_types, reqwest, tokio, toml_edit)
     src/
-      main.rs           cx-build lock: extracts cx.lock from pixi.lock's cx-env environment
+      main.rs           Subcommands: prepare (extracts cx.lock from pixi.lock's
+                        cx-env environment + applies excludes), payload (downloads
+                        packages and bundles into payload.tar.zst for cxz), and
+                        configure (overrides cx-env packages/channels/exclude in
+                        pixi.toml for custom builds)
 
   crates/cx-wasm/       cx-wasm WASM crate
     Cargo.toml          Workspace member (rattler, wasm-bindgen, web-sys)
@@ -415,15 +418,16 @@ packages = [
     "python >=3.12",
     "conda >=25.1",
     "conda-rattler-solver",
-    "conda-spawn",
+    "conda-spawn >=0.1.0",
     "conda-pypi",
     "conda-self",
-    "conda-workspaces",
+    "conda-global",
+    "conda-workspaces >=0.4.0",
 ]
 exclude = ["conda-libmamba-solver"]
 ```
 
-Both `build.rs` (compile-time) and the runtime binary read from `pixi.toml`. Changing it triggers an automatic re-solve on the next `cargo build`.
+Both `cx-build prepare` (which regenerates `cx.lock` from `pixi.lock`) and the runtime binary read from `pixi.toml`. Changing it requires re-running `pixi run lock` (to refresh `pixi.lock`) and `cargo run -p cx-build -- prepare` (to refresh `cx.lock`).
 
 ### Build-time environment variable overrides
 
@@ -466,6 +470,7 @@ Default prefix: `~/.cx`
 | conda-spawn | Subprocess-based activation (replaces `conda activate`) |
 | conda-pypi | PyPI interoperability (install, solve, convert) |
 | conda-self | Base environment self-management |
+| conda-global | Global tool installation and PATH management |
 | [conda-workspaces](https://conda-incubator.github.io/conda-workspaces/) | Multi-environment workspace and task management |
 
 ## Lockfile compatibility

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ cx installs a minimal conda stack from conda-forge:
 | conda-spawn >= 0.1.0 | Subprocess-based environment activation |
 | conda-pypi | PyPI interoperability |
 | conda-self | Base environment self-management |
+| conda-global | Global tool installation and PATH management |
 | [conda-workspaces](https://conda-incubator.github.io/conda-workspaces/) >= 0.4.0 | Multi-environment workspace and task management |
 
 The `conda-libmamba-solver` and its 27 exclusive native dependencies (libsolv, libarchive, libcurl, spdlog, etc.) are excluded by default, reducing the install size significantly.
@@ -188,6 +189,7 @@ packages = [
     "conda-spawn >=0.1.0",
     "conda-pypi",
     "conda-self",
+    "conda-global",
     "conda-workspaces >=0.4.0",
 ]
 exclude = ["conda-libmamba-solver"]

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ cx installs a minimal conda stack from conda-forge:
 | python >= 3.12 | Runtime |
 | conda >= 25.1 | Package manager |
 | conda-rattler-solver | Rust-based solver (replaces libmamba) |
-| conda-spawn | Subprocess-based environment activation |
+| conda-spawn >= 0.1.0 | Subprocess-based environment activation |
 | conda-pypi | PyPI interoperability |
 | conda-self | Base environment self-management |
-| [conda-workspaces](https://conda-incubator.github.io/conda-workspaces/) | Multi-environment workspace and task management |
+| [conda-workspaces](https://conda-incubator.github.io/conda-workspaces/) >= 0.4.0 | Multi-environment workspace and task management |
 
 The `conda-libmamba-solver` and its 27 exclusive native dependencies (libsolv, libarchive, libcurl, spdlog, etc.) are excluded by default, reducing the install size significantly.
 
@@ -185,15 +185,15 @@ packages = [
     "python >=3.12",
     "conda >=25.1",
     "conda-rattler-solver",
-    "conda-spawn",
+    "conda-spawn >=0.1.0",
     "conda-pypi",
     "conda-self",
-    "conda-workspaces",
+    "conda-workspaces >=0.4.0",
 ]
 exclude = ["conda-libmamba-solver"]
 ```
 
-Edit this section to customize what cx installs, then rebuild. You can also override these values at build time using environment variables — see [Building custom cx binaries](#building-custom-cx-binaries) below.
+Edit this section to customize what cx installs, then rebuild. You can also override these values at build time using environment variables -- see [Building custom cx binaries](#building-custom-cx-binaries) below.
 
 ## CLI reference
 

--- a/docs/background.md
+++ b/docs/background.md
@@ -28,7 +28,7 @@ project is the key enabler for cx's solver strategy:
 
 - Dependencies: only `conda >=25.5.0` + `py-rattler >=0.21.0`
 - [py-rattler](https://pypi.org/project/py-rattler/) is on PyPI with wheels
-  for all major platforms (~28-31 MB, statically-compiled Rust bindings)
+  for all major platforms (13-33 MB depending on platform, statically-compiled Rust bindings)
 - Uses [resolvo](https://github.com/mamba-org/resolvo), the fastest SAT solver
   in the conda ecosystem
 - Same solver used by [pixi](https://pixi.sh), under active development in the
@@ -42,8 +42,8 @@ project is the key enabler for cx's solver strategy:
 
 Because conda on conda-forge hard-depends on `conda-libmamba-solver`, cx
 uses a post-solve transitive dependency pruning algorithm to remove libmamba
-and its 27 exclusive dependencies, reducing the install from 113 to 86
-packages.
+and its exclusive dependencies, reducing the install from ~125 to ~95
+packages (varies by platform).
 
 ## PyPI distribution (the uv pattern)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,7 @@ packages = [
     "conda-spawn >=0.1.0",
     "conda-pypi",
     "conda-self",
+    "conda-global",
     "conda-workspaces >=0.4.0",
 ]
 exclude = ["conda-libmamba-solver"]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,10 +13,10 @@ packages = [
     "python >=3.12",
     "conda >=25.1",
     "conda-rattler-solver",
-    "conda-spawn",
+    "conda-spawn >=0.1.0",
     "conda-pypi",
     "conda-self",
-    "conda-workspaces",
+    "conda-workspaces >=0.4.0",
 ]
 exclude = ["conda-libmamba-solver"]
 ```

--- a/docs/features.md
+++ b/docs/features.md
@@ -28,7 +28,7 @@ uses `conda-rattler-solver` instead, these are unnecessary.
 cx removes them via a post-solve transitive dependency pruning algorithm:
 after the solver produces a complete solution, cx identifies packages that are
 *exclusively* required by the excluded packages and removes them. This reduces
-the install from 113 to 86 packages.
+the install from ~125 to ~95 packages (varies by platform).
 
 ## conda-rattler-solver
 
@@ -187,7 +187,7 @@ cx (7-11 MB)              cxz (50-95 MB)
 │  (7-11 MB)   │          │  (7-11 MB)       │
 ├──────────────┤          ├──────────────────┤
 │  lockfile    │          │  lockfile        │
-│  (39 KB)     │          │  (39 KB)         │
+│  (~130 KB)   │          │  (~130 KB)       │
 │              │          ├──────────────────┤
 │              │          │  payload.tar.zst │
 │              │          │  (40-85 MB)      │

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,11 +80,11 @@ cx installs a minimal conda stack from conda-forge:
 | python >= 3.12 | Runtime |
 | conda >= 25.1 | Package manager |
 | conda-rattler-solver | Rust-based solver (replaces libmamba) |
-| conda-spawn | Subprocess-based environment activation |
+| conda-spawn >= 0.1.0 | Subprocess-based environment activation |
 | conda-pypi | PyPI interoperability |
 | conda-self | Base environment self-management |
 | conda-global | Global tool installation and PATH management |
-| conda-workspaces | Multi-environment workspace and task management |
+| conda-workspaces >= 0.4.0 | Multi-environment workspace and task management |
 
 The `conda-libmamba-solver` and its 27 exclusive native dependencies are excluded by default, reducing the install size significantly.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -104,7 +104,7 @@ Bootstrap a full conda environment in ~3–5 seconds from an embedded lockfile. 
 :link: features
 :link-type: doc
 
-7-11 MB single binary. Installs 86 packages instead of 113 by excluding unnecessary native dependencies.
+7-11 MB single binary. Installs ~95 packages instead of ~125 by excluding unnecessary native dependencies.
 :::
 
 :::{grid-item-card} {octicon}`rocket` Modern

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -104,7 +104,7 @@ cx 0.1.0
   channels: conda-forge
   packages: python >=3.12, conda >=25.1, ...
   excludes: conda-libmamba-solver
-  installed: 86 packages
+  installed: 95 packages
   conda:    /Users/you/.cx/bin/conda
 ```
 :::


### PR DESCRIPTION
Update documentation to reflect the current state of the project after recent PRs (#56, #57, #58).

- Add conda-workspaces to the default plugins table in DESIGN.md and remove it from the "planned additions" section (it shipped a while ago)
- Add version pins (conda-spawn >=0.1.0, conda-workspaces >=0.4.0) to package tables and config examples in README.md, DESIGN.md, docs/index.md, and docs/configuration.md
- Add crates/xtask (cx-build) to the file structure in DESIGN.md
- Update pixi.toml and pixi.lock descriptions in the file structure
- Note sccache usage in the CI/CD section