### PR TITLE
fix: update test for rattler_conda_types PackageNameMatcher API change

### DIFF
--- a/crates/cx-wasm/src/solve.rs
+++ b/crates/cx-wasm/src/solve.rs
@@ -273,7 +273,10 @@ mod tests {
             rattler_conda_types::ParseStrictness::Lenient,
         )
         .unwrap();
-        assert!(spec.name.is_some());
+        assert!(matches!(
+            spec.name,
+            rattler_conda_types::PackageNameMatcher::Exact(_)
+        ));
         assert!(format!("{}", spec).contains("numpy"));
     }
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -48,9 +48,12 @@ fn gen_lock(check: bool, root_override: Option<PathBuf>) {
     let pixi_lock = LockFile::from_path(&pixi_lock_path)
         .unwrap_or_else(|e| panic!("failed to parse {}: {e}", pixi_lock_path.display()));
 
-    let cx_env = pixi_lock
-        .environment("cx-env")
-        .unwrap_or_else(|| panic!("cx-env environment not found in {}", pixi_lock_path.display()));
+    let cx_env = pixi_lock.environment("cx-env").unwrap_or_else(|| {
+        panic!(
+            "cx-env environment not found in {}",
+            pixi_lock_path.display()
+        )
+    });
 
     let pixi_toml = std::fs::read_to_string(&pixi_toml_path)
         .unwrap_or_else(|e| panic!("failed to read {}: {e}", pixi_toml_path.display()));
@@ -82,10 +85,7 @@ fn gen_lock(check: bool, root_override: Option<PathBuf>) {
     let mut builder = LockFileBuilder::new();
 
     if !cx_env.channels().is_empty() {
-        builder.set_channels(
-            "default",
-            cx_env.channels().iter().cloned(),
-        );
+        builder.set_channels("default", cx_env.channels().iter().cloned());
     }
 
     for (platform, packages) in cx_env.conda_packages_by_platform() {


### PR DESCRIPTION
## Summary

- Fix `PackageNameMatcher::is_some()` compile error in `crates/cx-wasm/src/solve.rs`
- `MatchSpec.name` changed from `Option<PackageName>` to `PackageNameMatcher` enum in rattler_conda_types 0.44.x — use `matches!()` instead

Unblocks all open PRs (#51, #59, #60) which are all failing CI due to this.

## Test plan

- `cargo test -p cx-wasm` passes locally