### PR TITLE
release: prepare 0.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
             os: windows-latest
     env:
       TARGET: ${{ matrix.target }}
+      SCCACHE_GHA_ENABLED: "true"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -94,6 +95,8 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
+    env:
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -116,6 +119,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    env:
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
             os: windows-latest
     env:
       TARGET: ${{ matrix.target }}
+      SCCACHE_GHA_ENABLED: "true"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -86,6 +87,7 @@ jobs:
             os: windows-latest
     env:
       TARGET: ${{ matrix.target }}
+      SCCACHE_GHA_ENABLED: "true"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -143,6 +145,8 @@ jobs:
             os: macos-latest
           - target: x86_64-pc-windows-msvc
             os: windows-latest
+    env:
+      SCCACHE_GHA_ENABLED: "true"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -304,6 +308,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-binaries]
     environment: crates-io
+    env:
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog
 
+## 0.6.0 (2026-05-06)
+
+### Features
+
+- **Slim `build.rs`** — Replace the 440-line `build.rs` (which compiled rattler, reqwest, tokio, etc. as build-dependencies) with a ~40-line script that copies pre-generated `cx.lock` and `payload.tar.zst` to `$OUT_DIR`. This eliminates ~292 duplicate crate compilations, roughly halving clean build time.
+- **`cx-build` crate** — New internal build tool (`crates/cx-build/`) with three subcommands:
+  - `prepare` — Extract `cx.lock` from `pixi.lock`'s `cx-env` environment and apply `[tool.cx].exclude` transitive dependency pruning.
+  - `payload` — Download packages from `cx.lock` and bundle into `payload.tar.zst` for `cxz` builds.
+  - `configure` — Override packages, channels, and exclusions in `pixi.toml` for custom builds (replaces `CX_PACKAGES`/`CX_CHANNELS`/`CX_EXCLUDE` env var overrides).
+- **`cx-env` pixi feature** — New `[feature.cx-env]` in `pixi.toml` that defines the bootstrap package set as a proper pixi environment, enabling `pixi lock` to solve dependencies instead of `build.rs`.
+- **`conda-global`** — Added to the default package set alongside existing conda plugins.
+- **`conda-workspaces >=0.4.0`** — Added to the default package set with version pin.
+- **sccache** — Local and CI build caching via `RUSTC_WRAPPER=sccache`.
+
+### Fixes
+
+- Stop self-deleting the `cx` binary on `cx uninstall` — now prints a hint for the user to remove it manually.
+- Clean subenvironment artifacts (envs, pkgs cache) on uninstall.
+- Precompile Python bytecode after bootstrap to avoid first-run `.pyc` compilation delays.
+- Remove unused `default_channels` from generated `.condarc`.
+- Pin `reqwest-middleware` and `sha2` versions to match rattler's transitive requirements.
+- Fix `getrandom` 0.3 usage in cx-wasm to match ahash's transitive dependency.
+- Fix JupyterLite `yarn.lock` TypeScript compatibility patch hash.
+
+### Build
+
+- Exclude filtering moved from runtime to build time: `src/exclude.rs` and `src/lib.rs` deleted; the `cx` binary trusts its pre-filtered `cx.lock`.
+- `--exclude`/`--no-exclude` CLI flags removed from `cx bootstrap`.
+- `action.yml` updated to use `cx-build configure` → `pixi lock` → `cx-build prepare` → `cargo build` pipeline.
+- `xtask` crate renamed to `cx-build`.
+
+### Docs
+
+- Updated `DESIGN.md`, `README.md`, `docs/configuration.md`, and `docs/index.md` to reflect `cx-build` rename, `conda-global` addition, and updated version pins.
+- Updated stale size and package count figures across all docs: lockfile 39 KB → ~130 KB, package counts 86/113 → ~95/~125, py-rattler wheel sizes ~28-31 MB → 13-33 MB.
+- Embedded remaining demo GIFs in docs and README.
+- Added VHS demos for conda-workspaces, quickstart, status, and passthrough.
+- Documented conda-workspaces in features, README, and index pages.
+
+### CI
+
+- Allow Codecov upload to fail on PRs.
+- Add `CHANGELOG.md` and `PLAN.md` to docs CI paths filter; drop release trigger from docs workflow.
+- Only deploy GitHub Pages from `main` branch.
+- Add Dependabot configuration for GitHub Actions, Cargo, npm, and pip.
+
+### Dependencies
+
+- Bump rattler ecosystem and other Rust dependencies.
+- Bump npm dependencies in cx-jupyterlite (lodash, postcss, brace-expansion, yaml).
+- Bump GitHub Actions to latest versions.
+
 ## 0.5.3 (2026-03-31)
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "conda-express"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "assert_cmd",
  "assert_matches",
@@ -1678,16 +1678,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is_ci"
@@ -4182,9 +4172,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
 dependencies = [
  "async-compression",
  "bitflags",
@@ -4194,13 +4184,13 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
- "iri-string",
  "pin-project-lite",
  "tokio",
  "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = [".", "crates/cx-wasm"]
 
 [package]
 name = "conda-express"
-version = "0.5.3"
+version = "0.6.0"
 edition = "2024"
 description = "A lightweight, single-binary conda bootstrapper — powered by rattler"
 license = "BSD-3-Clause"

--- a/Formula/cx.rb
+++ b/Formula/cx.rb
@@ -2,7 +2,7 @@ class Cx < Formula
   desc "Lightweight single-binary conda bootstrapper powered by rattler"
   homepage "https://github.com/jezdez/conda-express"
   license "BSD-3-Clause"
-  version "0.5.3"
+  version "0.6.0"
 
   on_macos do
     on_arm do


### PR DESCRIPTION
## Summary

- Bump version to 0.6.0 in `Cargo.toml`, `Cargo.lock`, and `Formula/cx.rb`
- Add CHANGELOG.md entry covering all 43 commits since 0.5.3

### Highlights

- **Slim `build.rs`** — replaced 440-line build script with ~40-line copy script; ~292 fewer duplicate crate compilations, roughly halving clean build time
- **`cx-build` crate** — new `prepare`/`payload`/`configure` subcommands replace the old build.rs solver and `CX_PACKAGES`/`CX_CHANNELS`/`CX_EXCLUDE` env var overrides
- **`cx-env` pixi feature** — bootstrap package set defined as a proper pixi environment
- **`conda-global`** and **`conda-workspaces >=0.4.0`** added to default package set
- **sccache** for local and CI build caching
- Uninstall fixes (no more self-deletion, subenvironment cleanup)
- Python bytecode precompilation after bootstrap
- Doc updates: corrected stale size/count figures, `cx-build` rename, demo GIFs

### Size verification (local osx-arm64 build)

| Metric | Documented | Actual |
|---|---|---|
| `cx` binary | 7-11 MB | 7.2 MB |
| `cx.lock` | ~130 KB | 130 KB |
| Filtered packages | ~95 | 92-98 (by platform) |
| Unfiltered packages | ~125 | 118-128 (by platform) |

## Test plan

- [x] `cargo check --locked` passes
- [x] `cx --version` prints `cx 0.6.0`
- [x] `pixi run build` produces working release binary
- [x] CI passes (release workflow builds all 5 platforms)
- [ ] After release: update `Formula/cx.rb` sha256 hashes from release artifacts