### PR TITLE
Security hardening: path traversal, decompression bombs, and HTTP timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -348,15 +348,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -607,12 +598,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,15 +676,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "cx-build"
 version = "0.1.0"
 dependencies = [
@@ -709,7 +685,7 @@ dependencies = [
  "rattler_lock",
  "reqwest",
  "serde",
- "sha2 0.11.0",
+ "sha2",
  "tar",
  "tokio",
  "toml",
@@ -733,7 +709,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_bytes",
  "serde_json",
- "sha2 0.11.0",
+ "sha2",
  "tar",
  "url",
  "wasm-bindgen",
@@ -812,20 +788,9 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
+ "block-buffer",
+ "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.0",
- "const-oid",
- "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -846,7 +811,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -935,7 +900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1447,15 +1412,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
-name = "hybrid-array"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1821,7 +1777,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1954,7 +1910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -2082,7 +2038,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2544,7 +2500,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2637,7 +2593,7 @@ checksum = "d5e004d0371d9671efc0c41c9d5311a21479db551fd68236a3299b7d7b8447f0"
 dependencies = [
  "anyhow",
  "console",
- "digest 0.10.7",
+ "digest",
  "dirs",
  "filetime",
  "fs-err",
@@ -2684,7 +2640,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "dashmap",
- "digest 0.10.7",
+ "digest",
  "dirs",
  "fs-err",
  "fs4",
@@ -2757,14 +2713,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa6239d5be357419ba579b1cda7fe0e140a22134ebc999adb62b818989fbc7c7"
 dependencies = [
  "blake2",
- "digest 0.10.7",
+ "digest",
  "generic-array",
  "hex",
  "md-5",
  "serde",
  "serde_bytes",
  "serde_with",
- "sha2 0.10.9",
+ "sha2",
  "tokio",
  "url",
 ]
@@ -2825,7 +2781,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "shlex",
  "tempfile",
  "thiserror 2.0.18",
@@ -3354,7 +3310,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3424,9 +3380,9 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.8.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
+checksum = "e5ff0cc5e135c8870a775d3320910cd9b564ec036b4dc0b8741629020be63f01"
 dependencies = [
  "twox-hash",
 ]
@@ -3691,18 +3647,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -3950,10 +3895,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3963,7 +3908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4090,9 +4035,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
@@ -4731,7 +4676,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4961,6 +4906,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4992,11 +4946,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5030,6 +5001,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5040,6 +5017,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5054,10 +5037,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5072,6 +5067,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5082,6 +5083,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5096,6 +5103,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5106,6 +5119,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -348,6 +348,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -598,6 +607,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,6 +691,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "cx-build"
 version = "0.1.0"
 dependencies = [
@@ -685,7 +709,7 @@ dependencies = [
  "rattler_lock",
  "reqwest",
  "serde",
- "sha2",
+ "sha2 0.11.0",
  "tar",
  "tokio",
  "toml",
@@ -709,7 +733,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_bytes",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tar",
  "url",
  "wasm-bindgen",
@@ -788,9 +812,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1412,6 +1447,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1910,7 +1954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2593,7 +2637,7 @@ checksum = "d5e004d0371d9671efc0c41c9d5311a21479db551fd68236a3299b7d7b8447f0"
 dependencies = [
  "anyhow",
  "console",
- "digest",
+ "digest 0.10.7",
  "dirs",
  "filetime",
  "fs-err",
@@ -2640,7 +2684,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "dashmap",
- "digest",
+ "digest 0.10.7",
  "dirs",
  "fs-err",
  "fs4",
@@ -2713,14 +2757,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa6239d5be357419ba579b1cda7fe0e140a22134ebc999adb62b818989fbc7c7"
 dependencies = [
  "blake2",
- "digest",
+ "digest 0.10.7",
  "generic-array",
  "hex",
  "md-5",
  "serde",
  "serde_bytes",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
  "url",
 ]
@@ -2781,7 +2825,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "shlex",
  "tempfile",
  "thiserror 2.0.18",
@@ -3647,7 +3691,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]

--- a/conda-emscripten/conda_emscripten/extractor.py
+++ b/conda-emscripten/conda_emscripten/extractor.py
@@ -4,17 +4,19 @@ Extracts .conda and .tar.bz2 packages via cx-wasm's Rust WASM code,
 with a Python streaming tarfile fallback for .tar.bz2 if WASM fails.
 """
 
+from __future__ import annotations
+
 import logging
 import os
+from pathlib import PurePosixPath
 from posixpath import normpath
 
 log = logging.getLogger(__name__)
 
 
-def _is_within(path, directory):
-    """Check that path is within directory after normalization."""
-    resolved = normpath(os.path.join(directory, path))
-    return resolved == directory or resolved.startswith(directory + os.sep)
+def is_within(path, directory):
+    """Check that *path* stays inside *directory* after resolving ``..``."""
+    return PurePosixPath(normpath(path)).is_relative_to(normpath(directory))
 
 
 def extract_wasm(source_path, dest_dir):
@@ -70,7 +72,7 @@ def _extract_via_wasm(source_path, dest_dir, filename):
     def on_file(path, data):
         nonlocal file_count
         full_path = os.path.join(dest_dir, path)
-        if not _is_within(full_path, dest_dir):
+        if not is_within(full_path, dest_dir):
             raise RuntimeError(f"extractor: path escapes destination: {path}")
         parent = os.path.dirname(full_path)
         if parent:
@@ -109,7 +111,7 @@ def _extract_tar_bz2(source_path, dest_dir, filename):
                 if not (member.isfile() or member.isdir() or member.issym() or member.islnk()):
                     continue
 
-                if not _is_within(join(dest_dir, member.name), dest_dir):
+                if not is_within(join(dest_dir, member.name), dest_dir):
                     raise RuntimeError(
                         f"extractor: tar path escapes destination: {member.name}"
                     )
@@ -121,7 +123,7 @@ def _extract_tar_bz2(source_path, dest_dir, filename):
                 if member.issym():
                     parent = dirname(member.name)
                     resolved = normpath(join(parent, member.linkname))
-                    if not _is_within(join(dest_dir, resolved), dest_dir):
+                    if not is_within(join(dest_dir, resolved), dest_dir):
                         raise RuntimeError(
                             f"extractor: symlink escapes destination: "
                             f"{member.name} -> {member.linkname}"
@@ -130,7 +132,7 @@ def _extract_tar_bz2(source_path, dest_dir, filename):
                     continue
 
                 if member.islnk():
-                    if not _is_within(join(dest_dir, member.linkname), dest_dir):
+                    if not is_within(join(dest_dir, member.linkname), dest_dir):
                         raise RuntimeError(
                             f"extractor: hardlink escapes destination: "
                             f"{member.name} -> {member.linkname}"

--- a/conda-emscripten/conda_emscripten/extractor.py
+++ b/conda-emscripten/conda_emscripten/extractor.py
@@ -6,8 +6,15 @@ with a Python streaming tarfile fallback for .tar.bz2 if WASM fails.
 
 import logging
 import os
+from posixpath import normpath
 
 log = logging.getLogger(__name__)
+
+
+def _is_within(path, directory):
+    """Check that path is within directory after normalization."""
+    resolved = normpath(os.path.join(directory, path))
+    return resolved == directory or resolved.startswith(directory + os.sep)
 
 
 def extract_wasm(source_path, dest_dir):
@@ -63,6 +70,8 @@ def _extract_via_wasm(source_path, dest_dir, filename):
     def on_file(path, data):
         nonlocal file_count
         full_path = os.path.join(dest_dir, path)
+        if not _is_within(full_path, dest_dir):
+            raise RuntimeError(f"extractor: path escapes destination: {path}")
         parent = os.path.dirname(full_path)
         if parent:
             os.makedirs(parent, exist_ok=True)
@@ -87,7 +96,7 @@ def _extract_tar_bz2(source_path, dest_dir, filename):
     required on Emscripten's MEMFS.
     """
     import tarfile
-    from posixpath import dirname, join, normpath
+    from posixpath import dirname, join
 
     os.makedirs(dest_dir, exist_ok=True)
     file_count = 0
@@ -97,6 +106,14 @@ def _extract_tar_bz2(source_path, dest_dir, filename):
     with open(source_path, "rb") as raw:
         with tarfile.open(fileobj=raw, mode="r|bz2") as tar:
             for member in tar:
+                if not (member.isfile() or member.isdir() or member.issym() or member.islnk()):
+                    continue
+
+                if not _is_within(join(dest_dir, member.name), dest_dir):
+                    raise RuntimeError(
+                        f"extractor: tar path escapes destination: {member.name}"
+                    )
+
                 if member.isdir():
                     os.makedirs(join(dest_dir, member.name), exist_ok=True)
                     continue
@@ -104,10 +121,20 @@ def _extract_tar_bz2(source_path, dest_dir, filename):
                 if member.issym():
                     parent = dirname(member.name)
                     resolved = normpath(join(parent, member.linkname))
+                    if not _is_within(join(dest_dir, resolved), dest_dir):
+                        raise RuntimeError(
+                            f"extractor: symlink escapes destination: "
+                            f"{member.name} -> {member.linkname}"
+                        )
                     deferred_links.append((member.name, resolved))
                     continue
 
                 if member.islnk():
+                    if not _is_within(join(dest_dir, member.linkname), dest_dir):
+                        raise RuntimeError(
+                            f"extractor: hardlink escapes destination: "
+                            f"{member.name} -> {member.linkname}"
+                        )
                     deferred_links.append((member.name, member.linkname))
                     continue
 

--- a/crates/cx-wasm/src/extract.rs
+++ b/crates/cx-wasm/src/extract.rs
@@ -56,6 +56,7 @@ where
 
         let entry_type = entry.header().entry_type();
 
+
         let path = entry
             .path()
             .map_err(|e| CxWasmError::ExtractFailed(format!("tar path error: {e}")))?

--- a/crates/cx-wasm/src/extract.rs
+++ b/crates/cx-wasm/src/extract.rs
@@ -56,6 +56,15 @@ where
 
         let entry_type = entry.header().entry_type();
 
+        if matches!(
+            entry_type,
+            tar::EntryType::Char
+                | tar::EntryType::Block
+                | tar::EntryType::Fifo
+                | tar::EntryType::GNUSparse
+        ) {
+            continue;
+        }
 
         let path = entry
             .path()

--- a/crates/cx-wasm/src/extract.rs
+++ b/crates/cx-wasm/src/extract.rs
@@ -215,3 +215,212 @@ where
     let mut tar = tar::Archive::new(decoder);
     stream_tar_entries(&mut tar, on_file)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_tar(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut builder = tar::Builder::new(Vec::new());
+        for (name, data) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(data.len() as u64);
+            header.set_mode(0o644);
+            header.set_entry_type(tar::EntryType::Regular);
+            header.set_cksum();
+            builder.append_data(&mut header, name, *data).unwrap();
+        }
+        builder.into_inner().unwrap()
+    }
+
+    fn build_tar_with_type(name: &str, entry_type: tar::EntryType) -> Vec<u8> {
+        let mut builder = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_mode(0o644);
+        header.set_entry_type(entry_type);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, name, &[] as &[u8])
+            .unwrap();
+        let mut h2 = tar::Header::new_gnu();
+        h2.set_size(2);
+        h2.set_mode(0o644);
+        h2.set_entry_type(tar::EntryType::Regular);
+        h2.set_cksum();
+        builder
+            .append_data(&mut h2, "ok.txt", b"ok" as &[u8])
+            .unwrap();
+        builder.into_inner().unwrap()
+    }
+
+    fn extract_raw_tar(tar_bytes: &[u8]) -> Result<ExtractStats, CxWasmError> {
+        let mut archive = tar::Archive::new(tar_bytes);
+        stream_tar_entries(&mut archive, &mut |_, _| Ok(()))
+    }
+
+    struct TarResult {
+        stats: ExtractStats,
+        files: Vec<(String, Vec<u8>)>,
+    }
+
+    fn extract_raw_tar_collecting(tar_bytes: &[u8]) -> Result<TarResult, CxWasmError> {
+        let mut files = Vec::new();
+        let mut archive = tar::Archive::new(tar_bytes);
+        let stats = stream_tar_entries(&mut archive, &mut |path, data| {
+            files.push((path.to_string(), data.to_vec()));
+            Ok(())
+        })?;
+        Ok(TarResult { stats, files })
+    }
+
+    // ── is_safe_tar_path ──
+
+    #[test]
+    fn test_safe_path_accepts_normal_paths() {
+        assert!(is_safe_tar_path("info/index.json"));
+        assert!(is_safe_tar_path("lib/python3.12/site-packages/foo.py"));
+        assert!(is_safe_tar_path("a/b/c.txt"));
+    }
+
+    #[test]
+    fn test_safe_path_rejects_empty() {
+        assert!(!is_safe_tar_path(""));
+    }
+
+    #[test]
+    fn test_safe_path_rejects_absolute() {
+        assert!(!is_safe_tar_path("/etc/passwd"));
+        assert!(!is_safe_tar_path("\\Windows\\system32"));
+    }
+
+    #[test]
+    fn test_safe_path_rejects_traversal() {
+        assert!(!is_safe_tar_path("../escape"));
+        assert!(!is_safe_tar_path("a/../../escape"));
+        assert!(!is_safe_tar_path("foo/.."));
+    }
+
+    #[test]
+    fn test_safe_path_rejects_backslash() {
+        assert!(!is_safe_tar_path("a\\b\\c"));
+    }
+
+    #[test]
+    fn test_safe_path_rejects_windows_drive() {
+        assert!(!is_safe_tar_path("C:\\Windows\\system32"));
+        assert!(!is_safe_tar_path("c:\\users"));
+        assert!(!is_safe_tar_path("D:\\data"));
+    }
+
+    // ── stream_tar_entries: path traversal ──
+
+    fn build_tar_raw_path(raw_path: &[u8], data: &[u8]) -> Vec<u8> {
+        let mut buf = vec![0u8; 512];
+        let len = raw_path.len().min(100);
+        buf[..len].copy_from_slice(&raw_path[..len]);
+        // mode
+        buf[100..107].copy_from_slice(b"0000644");
+        // size in octal
+        let size_str = format!("{:011o}", data.len());
+        buf[124..135].copy_from_slice(size_str.as_bytes());
+        // entry type: regular file
+        buf[156] = b'0';
+        // magic "ustar\0" + version "00"
+        buf[257..263].copy_from_slice(b"ustar\0");
+        buf[263..265].copy_from_slice(b"00");
+        // compute checksum
+        buf[148..156].copy_from_slice(b"        ");
+        let cksum: u32 = buf[..512].iter().map(|&b| b as u32).sum();
+        let cksum_str = format!("{:06o}\0 ", cksum);
+        buf[148..156].copy_from_slice(cksum_str.as_bytes());
+        // data block (padded to 512)
+        let mut data_block = data.to_vec();
+        let padding = (512 - data.len() % 512) % 512;
+        data_block.extend(vec![0u8; padding]);
+        buf.extend(data_block);
+        // end-of-archive marker (two zero blocks)
+        buf.extend(vec![0u8; 1024]);
+        buf
+    }
+
+    #[test]
+    fn test_tar_rejects_path_traversal() {
+        let tar_bytes = build_tar_raw_path(b"../escape.txt", b"bad");
+        let result = extract_raw_tar(&tar_bytes);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("unsafe tar path"), "error was: {err}");
+    }
+
+    #[test]
+    fn test_tar_rejects_absolute_path() {
+        let tar_bytes = build_tar_raw_path(b"/etc/passwd", b"root");
+        let result = extract_raw_tar(&tar_bytes);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("unsafe tar path"), "error was: {err}");
+    }
+
+    // ── stream_tar_entries: dangerous entry types ──
+
+    #[test]
+    fn test_tar_skips_char_device() {
+        let tar_bytes = build_tar_with_type("dev/null", tar::EntryType::Char);
+        let stats = extract_raw_tar(&tar_bytes).unwrap();
+        assert_eq!(
+            stats.file_count, 1,
+            "should only extract ok.txt, not device"
+        );
+    }
+
+    #[test]
+    fn test_tar_skips_block_device() {
+        let tar_bytes = build_tar_with_type("dev/sda", tar::EntryType::Block);
+        let stats = extract_raw_tar(&tar_bytes).unwrap();
+        assert_eq!(stats.file_count, 1);
+    }
+
+    #[test]
+    fn test_tar_skips_fifo() {
+        let tar_bytes = build_tar_with_type("tmp/pipe", tar::EntryType::Fifo);
+        let stats = extract_raw_tar(&tar_bytes).unwrap();
+        assert_eq!(stats.file_count, 1);
+    }
+
+    // ── stream_tar_entries: size limits ──
+
+    #[test]
+    fn test_tar_rejects_oversized_entry() {
+        let mut builder = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_size(MAX_ENTRY_SIZE + 1);
+        header.set_mode(0o644);
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "big.bin", std::io::empty())
+            .unwrap();
+        let tar_bytes = builder.into_inner().unwrap();
+        let result = extract_raw_tar(&tar_bytes);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("too large"), "error was: {err}");
+    }
+
+    // ── normal extraction ──
+
+    #[test]
+    fn test_tar_extracts_normal_files() {
+        let tar_bytes = build_tar(&[
+            ("info/index.json", b"{\"name\": \"test\"}"),
+            ("lib/foo.py", b"print('hello')"),
+        ]);
+        let result = extract_raw_tar_collecting(&tar_bytes).unwrap();
+        assert_eq!(result.stats.file_count, 2);
+        assert!(result.stats.total_size > 0);
+        let names: Vec<&str> = result.files.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(names.contains(&"info/index.json"));
+        assert!(names.contains(&"lib/foo.py"));
+    }
+}

--- a/crates/cx-wasm/src/sharded.rs
+++ b/crates/cx-wasm/src/sharded.rs
@@ -94,6 +94,8 @@ pub(crate) struct DecodedShardIndex {
     pub(crate) shards: BTreeMap<String, String>,
 }
 
+const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024; // 256 MB
+
 fn decompress_zstd(compressed: &[u8]) -> Result<Vec<u8>, CxWasmError> {
     if compressed.is_empty() {
         return Err(CxWasmError::RepodataParse(
@@ -105,9 +107,22 @@ fn decompress_zstd(compressed: &[u8]) -> Result<Vec<u8>, CxWasmError> {
         .map_err(|e| CxWasmError::RepodataParse(format!("zstd init: {e}")))?;
 
     let mut decompressed = Vec::new();
-    decoder
-        .read_to_end(&mut decompressed)
-        .map_err(|e| CxWasmError::RepodataParse(format!("zstd decompress: {e}")))?;
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = decoder
+            .read(&mut buf)
+            .map_err(|e| CxWasmError::RepodataParse(format!("zstd decompress: {e}")))?;
+        if n == 0 {
+            break;
+        }
+        decompressed.extend_from_slice(&buf[..n]);
+        if decompressed.len() > MAX_DECOMPRESSED_SIZE {
+            return Err(CxWasmError::RepodataParse(format!(
+                "decompressed data exceeds {} MB limit",
+                MAX_DECOMPRESSED_SIZE / (1024 * 1024)
+            )));
+        }
+    }
 
     Ok(decompressed)
 }

--- a/crates/cx-wasm/src/sharded.rs
+++ b/crates/cx-wasm/src/sharded.rs
@@ -430,3 +430,63 @@ pub(crate) fn fetch_sharded_records(
 
     Ok(all_records)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decompress_zstd_rejects_empty_input() {
+        let result = decompress_zstd(&[]);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("empty zstd input"), "error was: {err}");
+    }
+
+    #[test]
+    fn test_decompress_zstd_rejects_invalid_data() {
+        let result = decompress_zstd(&[0xFF, 0xFE, 0xFD, 0xFC]);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("zstd"), "error was: {err}");
+    }
+
+    #[test]
+    fn test_resolve_shards_base_url_absolute() {
+        let result = resolve_shards_base_url(
+            "https://cdn.example.com/shards",
+            "https://conda.anaconda.org/conda-forge/noarch/repodata_shards.msgpack.zst",
+        );
+        assert_eq!(result, "https://cdn.example.com/shards/");
+    }
+
+    #[test]
+    fn test_resolve_shards_base_url_relative() {
+        let result = resolve_shards_base_url(
+            "./shards",
+            "https://conda.anaconda.org/conda-forge/noarch/repodata_shards.msgpack.zst",
+        );
+        assert_eq!(
+            result,
+            "https://conda.anaconda.org/conda-forge/noarch/shards/"
+        );
+    }
+
+    #[test]
+    fn test_resolve_shards_base_url_empty() {
+        let result = resolve_shards_base_url(
+            "",
+            "https://conda.anaconda.org/conda-forge/noarch/repodata_shards.msgpack.zst",
+        );
+        assert_eq!(result, "https://conda.anaconda.org/conda-forge/noarch/");
+    }
+
+    #[test]
+    fn test_shard_index_url_format() {
+        let url = shard_index_url("https://conda.anaconda.org/conda-forge", "noarch");
+        assert_eq!(
+            url,
+            "https://conda.anaconda.org/conda-forge/noarch/repodata_shards.msgpack.zst"
+        );
+    }
+}

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -63,7 +63,6 @@ fn reject_dangerous_prefix(prefix: &Path) -> miette::Result<()> {
     Ok(())
 }
 
-
 pub(crate) fn validate_bootstrap_flags(
     offline: bool,
     no_lock: bool,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -63,6 +63,7 @@ fn reject_dangerous_prefix(prefix: &Path) -> miette::Result<()> {
     Ok(())
 }
 
+
 pub(crate) fn validate_bootstrap_flags(
     offline: bool,
     no_lock: bool,

--- a/src/install.rs
+++ b/src/install.rs
@@ -244,10 +244,37 @@ pub fn extract_embedded_payload() -> miette::Result<Option<PathBuf>> {
         .into_diagnostic()
         .context("failed to decompress embedded payload")?;
     let mut archive = tar::Archive::new(decoder);
-    archive
-        .unpack(tmp_dir.path())
+    archive.set_preserve_permissions(false);
+    archive.set_unpack_xattrs(false);
+    archive.set_preserve_ownerships(false);
+    for entry in archive
+        .entries()
         .into_diagnostic()
-        .context("failed to unpack embedded payload")?;
+        .context("failed to read embedded payload entries")?
+    {
+        let mut entry = entry
+            .into_diagnostic()
+            .context("failed to read payload entry")?;
+        let path = entry
+            .path()
+            .into_diagnostic()
+            .context("failed to read payload entry path")?;
+        let path_str = path.to_string_lossy();
+        if path_str.contains("..") || path.is_absolute() {
+            return Err(miette::miette!(
+                "unsafe path in embedded payload: {}",
+                path_str
+            ));
+        }
+        let entry_type = entry.header().entry_type();
+        if entry_type.is_symlink() || entry_type.is_hard_link() {
+            continue;
+        }
+        entry
+            .unpack_in(tmp_dir.path())
+            .into_diagnostic()
+            .context("failed to unpack payload entry")?;
+    }
 
     eprintln!(
         "   Extracted embedded payload ({:.1} MB) to {}",
@@ -426,6 +453,8 @@ pub(crate) fn parse_specs(specs: &[String]) -> miette::Result<Vec<MatchSpec>> {
 fn make_download_client() -> miette::Result<reqwest_middleware::ClientWithMiddleware> {
     let raw = reqwest::Client::builder()
         .no_gzip()
+        .connect_timeout(Duration::from_secs(30))
+        .timeout(Duration::from_secs(600))
         .build()
         .into_diagnostic()
         .context("failed to create HTTP client")?;

--- a/tests/conda_prompt_stdout_pipe_regression.rs
+++ b/tests/conda_prompt_stdout_pipe_regression.rs
@@ -12,7 +12,7 @@
 
 #[cfg(unix)]
 mod unix {
-    use std::io::{BufRead, BufReader, Write};
+    use std::io::{BufRead, BufReader, Read, Write};
     use std::process::{Command, Stdio};
     use std::sync::mpsc;
     use std::thread;
@@ -59,14 +59,22 @@ mod unix {
                         .expect("read_line from piped child stdout");
                     line
                 }
-                FirstLineMode::LinesIterator => buf
-                    .lines()
-                    .next()
-                    .expect("lines iterator should yield")
-                    .expect("first line from piped child stdout"),
+                FirstLineMode::LinesIterator => {
+                    let first = buf
+                        .by_ref()
+                        .lines()
+                        .next()
+                        .expect("lines iterator should yield")
+                        .expect("first line from piped child stdout");
+                    first
+                }
             };
             tx.send((start.elapsed(), line))
                 .expect("send timing + line to main thread");
+            // Drain remaining output so the child doesn't get SIGPIPE on its
+            // final `echo after`.
+            let mut rest = String::new();
+            let _ = buf.read_to_string(&mut rest);
         });
 
         const DELAY: Duration = Duration::from_millis(150);
@@ -76,6 +84,7 @@ mod unix {
             .write_all(b"y\n")
             .expect("answer child's read as the user would");
         stdin.flush().expect("flush stdin");
+        drop(stdin);
 
         let (elapsed, line) = rx
             .recv_timeout(Duration::from_secs(5))
@@ -84,7 +93,7 @@ mod unix {
         reader.join().expect("reader thread panicked");
 
         let status = child.wait().expect("wait child");
-        assert!(status.success(), "child should exit 0");
+        assert!(status.success(), "child exited {:?}", status);
 
         assert!(
             elapsed >= DELAY.saturating_sub(Duration::from_millis(30)),

--- a/tests/conda_prompt_stdout_pipe_regression.rs
+++ b/tests/conda_prompt_stdout_pipe_regression.rs
@@ -59,15 +59,12 @@ mod unix {
                         .expect("read_line from piped child stdout");
                     line
                 }
-                FirstLineMode::LinesIterator => {
-                    let first = buf
-                        .by_ref()
-                        .lines()
-                        .next()
-                        .expect("lines iterator should yield")
-                        .expect("first line from piped child stdout");
-                    first
-                }
+                FirstLineMode::LinesIterator => buf
+                    .by_ref()
+                    .lines()
+                    .next()
+                    .expect("lines iterator should yield")
+                    .expect("first line from piped child stdout"),
             };
             tx.send((start.elapsed(), line))
                 .expect("send timing + line to main thread");


### PR DESCRIPTION
## Summary

- **Tar path traversal protection**: Reject `..`, absolute paths, backslashes, and Windows drive letters in tar entries (Rust extractor); validate all extracted paths stay within destination directory (Python extractor)
- **Decompression bomb mitigation**: Add per-entry (256 MB) and total (2 GB) size limits in WASM tar extraction; add 256 MB decompressed size limit for sharded repodata; use chunked reading instead of unbounded `read_to_end`
- **Dangerous entry type filtering**: Skip char/block devices, FIFOs, and GNU sparse entries in tar archives
- **Symlink/hardlink boundary validation**: Verify link targets resolve within the destination directory before extraction (Python fallback extractor)
- **Native installer hardening**: Replace blanket `archive.unpack()` with entry-by-entry extraction, disable permission/ownership/xattr preservation, skip symlinks/hardlinks in embedded payload, reject path traversal
- **HTTP timeouts**: Add 30s connect timeout and 600s total timeout to prevent hanging downloads

## Test plan

- [x] Verify `cx bootstrap` still completes successfully on macOS/Linux
- [x] Verify conda package extraction works for both `.conda` and `.tar.bz2` formats
- [x] Confirm malicious tar entries (path traversal, oversized) are rejected with clear errors
- [x] Check WASM extraction in JupyterLite demo still functions