### PR TITLE
Prepare conda-express 26.5.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           if [[ ! "$RELEASE_TAG" =~ ^[0-9]+[.][0-9]+[.][0-9]+([.]post[0-9]+)?$ ]]; then
             echo "Invalid release tag: ${RELEASE_TAG}" >&2
-            echo "Use a version tag such as 26.5.0 or 26.5.0.post1." >&2
+            echo "Use a version tag such as 26.5.2 or 26.5.2.post1." >&2
             exit 1
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 - Build the published `cx` and `cxz` runtime binaries with conda-ship instead
   of the old repository-local Rust builder.
-- Keep conda-express focused on Jannis Leidel's `cx` / `cxz` distribution.
+- Keep conda-express focused on the `cx` / `cxz` distribution.
   Custom runtime builds now belong in conda-ship.
 - Continue publishing GitHub Release artifacts, installer scripts, Docker
   images, the Homebrew tap formula, and PyPI wheels.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,43 @@
 # Changelog
 
-## 26.5.0 (unreleased)
+## 26.5.2 (unreleased)
 
 ### Versioning
 
-- conda-express now follows the conda runtime version. The `26.5.0` release
-  bootstraps conda `26.5.0`; conda-express-only rebuilds should use
-  post-release versions such as `26.5.0.post1`.
+- conda-express now follows the conda runtime version. The `26.5.2` release
+  bootstraps conda `26.5.2`.
+- conda-express-only rebuilds should use post-release versions such as
+  `26.5.2.post1`.
 
 ### Runtime
 
-- Pin the runtime conda package exactly to `26.5.0` and refresh the runtime
-  lockfile across all supported platforms.
-- Require `conda-workspaces >=0.5.0` in the default runtime package set.
+- Pin the runtime conda package exactly to `26.5.2` across linux-64,
+  linux-aarch64, osx-64, osx-arm64, and win-64.
+- Keep the managed runtime prefix at `~/.conda/express` and keep the base
+  prefix protected with the CEP 22 frozen marker after bootstrap.
+- Include `conda-completion >=0.2.0` and `conda-workspaces >=0.5.0` in the
+  default runtime package set, alongside `conda-rattler-solver`,
+  `conda-spawn`, `conda-pypi`, `conda-self`, and `conda-global`.
+
+### Distribution
+
+- Build the published `cx` and `cxz` runtime binaries with conda-ship instead
+  of the old repository-local Rust builder.
+- Keep conda-express focused on Jannis Leidel's `cx` / `cxz` distribution.
+  Custom runtime builds now belong in conda-ship.
+- Continue publishing GitHub Release artifacts, installer scripts, Docker
+  images, the Homebrew tap formula, and PyPI wheels.
+- Stop publishing new crates.io releases.
+- Attest release artifacts before publishing the immutable GitHub Release.
+
+### Upgrade Notes
+
+- Early `cx` releases used `~/.cx`; current releases use `~/.conda/express`.
+  Upgrading the binary does not migrate that old prefix. Keep `~/.cx` until
+  you have recreated or archived any environments you still need, then remove
+  it manually.
+- If an old Cargo-installed `cx` is still earlier on `PATH`, remove it and
+  install `cx` through one of the current distribution channels.
 
 ### Installer Scripts
 
@@ -20,25 +45,29 @@
   bootstrapping, so scripted offline installs use the documented bundle and
   network settings.
 
+### Documentation
+
+- Rework the docs around conda-express as a distribution built with
+  conda-ship, with conda-ship linked as the tool for custom runtimes.
+- Add focused guides for installer-style conda distributions, offline and
+  air-gapped use, release artifact verification, and upgrading from early `cx`
+  releases.
+
 ## 0.6.0 (2026-05-06)
-
-Generic builder changes from this release now live in
-[`conda-ship`](https://github.com/jezdez/conda-ship). See the `conda-ship` changelog for
-the moved `cx-build`, lock derivation, bundle, and build pipeline history.
-
-### Upgrade Notes
-
-- Current `cx` releases bootstrap into `~/.conda/express`. Early releases used
-  `~/.cx`; upgrading the binary does not migrate that old prefix. Keep `~/.cx`
-  until you have recreated or archived any environments you still need, then
-  remove it manually.
-- conda-express no longer publishes new releases to crates.io. Use Homebrew,
-  the installer scripts, GitHub Releases, Docker, or PyPI instead.
 
 ### Features
 
+- **Slim `build.rs`** — Replace the 440-line `build.rs` with a small script
+  that copies pre-generated `cx.lock` and `payload.tar.zst` to `$OUT_DIR`,
+  reducing duplicate build-dependency compilation.
+- **`cx-build` crate** — Add an internal build tool with `prepare`, `payload`,
+  and `configure` subcommands for deriving `cx.lock`, downloading package
+  archives, and configuring custom builds.
+- **`cx-env` Pixi feature** — Define the bootstrap package set as a Pixi
+  environment so `pixi lock` solves dependencies instead of `build.rs`.
 - **`conda-global`** — Added to the default package set alongside existing conda plugins.
 - **`conda-workspaces >=0.4.0`** — Added to the default package set with version pin.
+- **sccache** — Local and CI build caching via `RUSTC_WRAPPER=sccache`.
 
 ### Fixes
 
@@ -47,10 +76,21 @@ the moved `cx-build`, lock derivation, bundle, and build pipeline history.
 - Precompile Python bytecode after bootstrap to avoid first-run `.pyc` compilation delays.
 - Remove unused `default_channels` from generated `.condarc`.
 - Pin `reqwest-middleware` and `sha2` versions to match rattler's transitive requirements.
+- Fix `getrandom` 0.3 usage in cx-wasm to match ahash's transitive dependency.
+- Fix JupyterLite `yarn.lock` TypeScript compatibility patch hash.
+
+### Build
+
+- Move exclude filtering from runtime to build time; the `cx` binary trusts its
+  pre-filtered `cx.lock`.
+- Remove `--exclude` and `--no-exclude` from `cx bootstrap`.
+- Update `action.yml` to use the `cx-build configure`, `pixi lock`,
+  `cx-build prepare`, and `cargo build` pipeline.
+- Rename the `xtask` crate to `cx-build`.
 
 ### Docs
 
-- Updated `DESIGN.md`, `README.md`, `docs/configuration.md`, and `docs/index.md` to reflect `conda-global` addition and updated version pins.
+- Updated `DESIGN.md`, `README.md`, `docs/configuration.md`, and `docs/index.md` to reflect `cx-build` rename, `conda-global` addition, and updated version pins.
 - Updated stale size and package count figures across all docs: lockfile 39 KB → ~130 KB, package counts 86/113 → ~95/~125, py-rattler wheel sizes ~28-31 MB → 13-33 MB.
 - Embedded remaining demo GIFs in docs and README.
 - Added VHS demos for conda-workspaces, quickstart, status, and passthrough.
@@ -58,18 +98,19 @@ the moved `cx-build`, lock derivation, bundle, and build pipeline history.
 
 ### CI
 
-- Build releases from tags by creating the GitHub release only after the
-  conda-ship-built binaries and PyPI wheels have completed. Runtime artifacts
-  are attested before upload, and immutable releases are published once instead
-  of being modified after publication.
 - Allow Codecov upload to fail on PRs.
 - Add `CHANGELOG.md` and `PLAN.md` to docs CI paths filter; drop release trigger from docs workflow.
 - Only deploy GitHub Pages from `main` branch.
-- Add Dependabot configuration for GitHub Actions and pip.
+- Add Dependabot configuration for GitHub Actions, Cargo, npm, and pip.
+- Fix `CX_EMBED_PAYLOAD` env var for Windows PowerShell compatibility.
+- Scope `cargo publish` to the `conda-express` crate only.
+- Make Trivy CVE scan non-blocking for upstream base image vulnerabilities.
+- Enable sccache GitHub Actions cache backend for persistent build caching.
 
 ### Dependencies
 
 - Bump rattler ecosystem and other Rust dependencies.
+- Bump npm dependencies in cx-jupyterlite.
 - Bump GitHub Actions to latest versions.
 
 ## 0.5.3 (2026-03-31)

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 A single-binary bootstrapper for [conda](https://github.com/conda/conda), powered by [rattler](https://github.com/conda/rattler). The `cx` binary is short for **c**onda e**x**press.
 
-conda-express is Jannis Leidel's distribution project for the `cx` and `cxz`
-binaries. It is not an official conda distribution.
+conda-express is the distribution project for the `cx` and `cxz` binaries. It
+is not an official conda distribution.
 
 cx offers an alternative to the Anaconda Distribution, Miniconda, and Miniforge constructor-style installer pattern: a 7-11 MB native binary that bootstraps a managed conda base environment from a locked package set.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cx installs a managed conda stack from conda-forge:
 | Package | Role |
 |---|---|
 | python >= 3.12 | Runtime |
-| conda == 26.5.0 | Package manager |
+| conda == 26.5.2 | Package manager |
 | conda-rattler-solver | Rust-based solver without libmamba's native dependency chain |
 | conda-spawn >= 0.1.0 | Subprocess-based environment activation |
 | conda-completion >= 0.2.0 | Shell completion support |
@@ -63,9 +63,9 @@ The `conda-libmamba-solver` and its 27 exclusive native dependencies (libsolv, l
 ## Versioning
 
 conda-express versions follow the conda version in the runtime lock. For
-example, `conda-express 26.5.0` bootstraps conda `26.5.0`. If conda-express
+example, `conda-express 26.5.2` bootstraps conda `26.5.2`. If conda-express
 needs a packaging-only rebuild without changing the bundled conda version, it
-uses a post-release version such as `26.5.0.post1`.
+uses a post-release version such as `26.5.2.post1`.
 
 ## Installation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,7 +45,7 @@ The `runtime` source environment installs:
 | Package | Role |
 |---|---|
 | `python >=3.12` | Python runtime for conda |
-| `conda ==26.5.0` | Package manager |
+| `conda ==26.5.2` | Package manager |
 | `conda-rattler-solver` | Default solver |
 | `conda-spawn >=0.1.0` | Subshell activation |
 | `conda-completion >=0.2.0` | Shell completion |
@@ -60,11 +60,11 @@ conda-express uses `conda-rattler-solver`.
 ## Versioning Policy
 
 conda-express release versions follow the exact conda package version in the
-runtime lock. A `26.5.0` conda-express release bootstraps conda `26.5.0` on
+runtime lock. A `26.5.2` conda-express release bootstraps conda `26.5.2` on
 every supported platform.
 
 Use `.postN` releases for conda-express-only rebuilds that keep the same conda
-runtime package, for example `26.5.0.post1`.
+runtime package, for example `26.5.2.post1`.
 
 See {doc}`features` for why the distribution version follows the conda runtime
 version.

--- a/docs/features.md
+++ b/docs/features.md
@@ -26,13 +26,13 @@ for the generic build model.
 ## Versioning follows conda
 
 conda-express is a conda distribution, so its release version follows the
-exact conda package version in the runtime lock. A `26.5.0` conda-express
-release bootstraps conda `26.5.0` on every supported platform.
+exact conda package version in the runtime lock. A `26.5.2` conda-express
+release bootstraps conda `26.5.2` on every supported platform.
 
 This makes direct downloads, PyPI wheels, Homebrew formula updates, Docker
 tags, and installer-script `CX_VERSION` values point at the same conda runtime
 version. If conda-express needs a packaging-only rebuild without changing the
-conda package, it uses a post-release version such as `26.5.0.post1`.
+conda package, it uses a post-release version such as `26.5.2.post1`.
 
 ## Package exclusion
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ binaries, not an official conda distribution. Custom bootstrap binaries are buil
 {external+conda-ship:doc}`conda-ship <index>`.
 
 Release versions follow the conda runtime version in the built-in lock. For
-example, `cx 26.5.0` bootstraps conda `26.5.0`.
+example, `cx 26.5.2` bootstraps conda `26.5.2`.
 
 ## Install `cx`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,8 +8,8 @@ installed `conda` executable.
 `cxz` is the offline variant. It carries the locked package archives in the
 binary so it can bootstrap without network access.
 
-`conda-express` is Jannis Leidel's distribution project for the `cx` and `cxz`
-binaries, not an official conda distribution. Custom bootstrap binaries are built with
+`conda-express` is the distribution project for the `cx` and `cxz` binaries,
+not an official conda distribution. Custom bootstrap binaries are built with
 {external+conda-ship:doc}`conda-ship <index>`.
 
 Release versions follow the conda runtime version in the built-in lock. For

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -47,19 +47,19 @@ All options work as environment variables on both platforms:
 | `CX_OFFLINE` | *(unset)* | Set to force offline bootstrap |
 
 `CX_VERSION` uses conda-express release versions, which follow the conda
-runtime version in the lock. For example, `26.5.0` installs a `cx` release
-that bootstraps conda `26.5.0`.
+runtime version in the lock. For example, `26.5.2` installs a `cx` release
+that bootstraps conda `26.5.2`.
 
 Unix example:
 
 ```bash
-curl -fsSL https://jezdez.github.io/conda-express/get-cx.sh | env CX_VERSION=26.5.0 sh
+curl -fsSL https://jezdez.github.io/conda-express/get-cx.sh | env CX_VERSION=26.5.2 sh
 ```
 
 PowerShell example:
 
 ```powershell
-$Env:CX_VERSION = "26.5.0"; irm https://jezdez.github.io/conda-express/get-cx.ps1 | iex
+$Env:CX_VERSION = "26.5.2"; irm https://jezdez.github.io/conda-express/get-cx.ps1 | iex
 ```
 :::
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -103,7 +103,7 @@ cx status
 :class: dropdown
 
 ```text
-cx 26.5.0
+cx 26.5.2
   path:      /Users/you/.conda/express
   channels:  https://conda.anaconda.org/conda-forge/
   packages:  python, conda, conda-rattler-solver, ...

--- a/docs/reference/installer.md
+++ b/docs/reference/installer.md
@@ -69,7 +69,7 @@ All options are set via environment variables and work on both platforms.
 | Variable | Default | Description |
 |---|---|---|
 | `CX_INSTALL_DIR` | `~/.local/bin` (Unix) or `%USERPROFILE%\.local\bin` (Windows) | Directory to place the `cx` binary |
-| `CX_VERSION` | `latest` | Version to install (without `v` prefix, e.g. `26.5.0`) |
+| `CX_VERSION` | `latest` | Version to install (without `v` prefix, e.g. `26.5.2`) |
 | `CX_NO_PATH_UPDATE` | *(unset)* | Set to any value to skip shell profile / PATH modification |
 | `CX_NO_BOOTSTRAP` | *(unset)* | Set to any value to skip running `cx bootstrap` after install |
 | `CX_SKIP_VERIFY` | *(unset)* | Set to any value to skip checksum verification |
@@ -77,8 +77,8 @@ All options are set via environment variables and work on both platforms.
 | `CX_OFFLINE` | *(unset)* | Set to any truthy value to disable network during bootstrap |
 
 `CX_VERSION` selects a conda-express release. Release versions follow the conda
-runtime version in the lock; `26.5.0` bootstraps conda `26.5.0`, while
-`26.5.0.post1` would be a conda-express-only rebuild with the same conda
+runtime version in the lock; `26.5.2` bootstraps conda `26.5.2`, while
+`26.5.2.post1` would be a conda-express-only rebuild with the same conda
 runtime package.
 
 :::{tip}
@@ -93,7 +93,7 @@ archives and requires no separate bundle directory. See
 Install a specific version:
 
 ```bash
-curl -fsSL https://jezdez.github.io/conda-express/get-cx.sh | env CX_VERSION=26.5.0 sh
+curl -fsSL https://jezdez.github.io/conda-express/get-cx.sh | env CX_VERSION=26.5.2 sh
 ```
 
 Install to a custom directory without bootstrap:
@@ -105,13 +105,13 @@ curl -fsSL https://jezdez.github.io/conda-express/get-cx.sh | env CX_INSTALL_DIR
 PowerShell with options:
 
 ```powershell
-$Env:CX_VERSION = "26.5.0"; irm https://jezdez.github.io/conda-express/get-cx.ps1 | iex
+$Env:CX_VERSION = "26.5.2"; irm https://jezdez.github.io/conda-express/get-cx.ps1 | iex
 ```
 
 The PowerShell script also accepts named parameters when invoked directly:
 
 ```powershell
-.\get-cx.ps1 -Version 26.5.0 -InstallDir C:\tools -NoBootstrap
+.\get-cx.ps1 -Version 26.5.2 -InstallDir C:\tools -NoBootstrap
 ```
 
 For an offline `cx` bootstrap with a bundle directory:

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -1,6 +1,6 @@
 # Project scope
 
-`conda-express` is Jannis Leidel's distribution repo for `cx` and `cxz`.
+`conda-express` is the distribution repo for `cx` and `cxz`.
 
 It is not an official conda distribution and it is not the generic builder.
 The generic builder responsibility lives in
@@ -8,7 +8,7 @@ The generic builder responsibility lives in
 
 | Project | Role |
 |---|---|
-| `conda-express` | Jannis Leidel's opinionated native conda distribution that publishes `cx` and `cxz` |
+| `conda-express` | Opinionated native conda distribution that publishes `cx` and `cxz` |
 | {external+conda-ship:doc}`conda-ship <index>` | Generic builder/runtime for ready-to-run conda bootstrap binaries |
 
 ## What conda-express owns

--- a/pixi.lock
+++ b/pixi.lock
@@ -374,7 +374,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py314h4a8dc5f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-26.5.0-py314hdafbbf9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-26.5.2-py314hdafbbf9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-completer-0.2.0-h392c2a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-pypi-0.9.0-py314hdafbbf9_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-trampoline-0.1.1-h392c2a1_2.conda
@@ -513,7 +513,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.6-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cffi-2.0.0-py314h0bd77cf_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/conda-26.5.0-py314h28a4750_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/conda-26.5.2-py314h28a4750_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/conda-completer-0.2.0-he07f0f4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/conda-pypi-0.9.0-py314ha42fa4b_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/conda-trampoline-0.1.1-he07f0f4_2.conda
@@ -725,7 +725,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.6-hb5e19a0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-2.0.0-py314h8ca4d5a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/conda-26.5.0-py314hee6578b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/conda-26.5.2-py314hee6578b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/conda-completer-0.2.0-h21e0505_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/conda-pypi-0.9.0-py314hee6578b_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/conda-trampoline-0.1.1-h21e0505_2.conda
@@ -857,7 +857,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.0.0-py314h44086f9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/conda-26.5.0-py314h4dc9dd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/conda-26.5.2-py314h4dc9dd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/conda-completer-0.2.0-h046cac1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/conda-pypi-0.9.0-py314h4dc9dd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/conda-trampoline-0.1.1-h046cac1_2.conda
@@ -988,7 +988,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.2.0-py314he701e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.0.0-py314h5a2d7ad_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/conda-26.5.0-py314h86ab7b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/conda-26.5.2-py314h86ab7b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/conda-completer-0.2.0-hc05bbc4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/conda-pypi-0.9.0-py314h86ab7b2_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/conda-trampoline-0.1.1-hc05bbc4_2.conda
@@ -1100,9 +1100,9 @@ packages:
   license_family: MIT
   size: 300271
   timestamp: 1761203085220
-- conda: https://conda.anaconda.org/conda-forge/linux-64/conda-26.5.0-py314hdafbbf9_1.conda
-  sha256: 937d7ab51c90f770aa4ed4d7559b061c3c95fa1845ebfe6e93ab358a7e0fdde8
-  md5: fcf86b16ca51e998b16ae9dd52674e39
+- conda: https://conda.anaconda.org/conda-forge/linux-64/conda-26.5.2-py314hdafbbf9_0.conda
+  sha256: 52e72927c8c7dee57b1e88d5244adb7c1770ea213654cb9bbf2e4a982a7a9974
+  md5: 6242a3b4e47772eaa2e3dd0c7982dabd
   depends:
   - archspec >=0.2.3
   - boltons >=23.0.0
@@ -1130,13 +1130,12 @@ packages:
   - truststore >=0.8.0
   - zstandard >=0.19.0
   constrains:
+  - conda-content-trust >=0.3.0
   - conda-env >=2.6
   - conda-build >=25.9
-  - conda-content-trust >=0.3.0
   license: BSD-3-Clause
-  license_family: BSD
-  size: 1355401
-  timestamp: 1778941956611
+  size: 1358179
+  timestamp: 1780392597206
 - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-completer-0.2.0-h392c2a1_0.conda
   noarch: python
   sha256: 44d5e7e8b90ce723194d914e43b9374cbcfc66967c35f3eaa9a539758bb4b334
@@ -2074,9 +2073,9 @@ packages:
   license_family: MIT
   size: 318357
   timestamp: 1761203973223
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/conda-26.5.0-py314h28a4750_1.conda
-  sha256: 991522733830ded10428339635db73c5e54cf9802cc4f5748f8828eaad57f8ed
-  md5: a98acf35cdefcf0cebebd71eea9b5aa5
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/conda-26.5.2-py314h28a4750_0.conda
+  sha256: 96595b0478e40b34d391838191df7792ab497d11baf534033cc3b069eaa5672a
+  md5: 34e9c0ff34aefd932adfa736fb4fcb62
   depends:
   - archspec >=0.2.3
   - boltons >=23.0.0
@@ -2109,9 +2108,8 @@ packages:
   - conda-env >=2.6
   - conda-content-trust >=0.3.0
   license: BSD-3-Clause
-  license_family: BSD
-  size: 1359756
-  timestamp: 1778941998175
+  size: 1359762
+  timestamp: 1780392700381
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/conda-completer-0.2.0-he07f0f4_0.conda
   noarch: python
   sha256: 4450b8dc036ae4707d040bd912fe2f2e0faf95a70d3315c228ba1a2244c6c522
@@ -4196,9 +4194,9 @@ packages:
   license_family: MIT
   size: 293633
   timestamp: 1761203106369
-- conda: https://conda.anaconda.org/conda-forge/osx-64/conda-26.5.0-py314hee6578b_1.conda
-  sha256: 2808a7a97ee6748bfa25a4821d900ffd90e79282b7594cbe71fdd4b4014793a9
-  md5: f9dd6a0a6ef1c7b10eeb5bcff7f14bed
+- conda: https://conda.anaconda.org/conda-forge/osx-64/conda-26.5.2-py314hee6578b_0.conda
+  sha256: 76a56a611d564b372e5df350a7df02bc1ad400db961564557cfd14ae3909ddf4
+  md5: 156f1b9acafda23be411a20481a28b74
   depends:
   - archspec >=0.2.3
   - boltons >=23.0.0
@@ -4227,12 +4225,11 @@ packages:
   - zstandard >=0.19.0
   constrains:
   - conda-content-trust >=0.3.0
-  - conda-build >=25.9
   - conda-env >=2.6
+  - conda-build >=25.9
   license: BSD-3-Clause
-  license_family: BSD
-  size: 1357796
-  timestamp: 1778942301410
+  size: 1359153
+  timestamp: 1780393269637
 - conda: https://conda.anaconda.org/conda-forge/osx-64/conda-completer-0.2.0-h21e0505_0.conda
   noarch: python
   sha256: 7e11443f91d8b901db74dc476eb0b46842b760fbc22ea0618178d70c308a3b8d
@@ -5007,9 +5004,9 @@ packages:
   license_family: MIT
   size: 292983
   timestamp: 1761203354051
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/conda-26.5.0-py314h4dc9dd8_1.conda
-  sha256: 3df8a7398920a9ccb59748bcc3417a58fbc84b9327a14cb87b34aaa0120fbe68
-  md5: 2c96d6ad8e0d688f6baf7f8f42d65fc1
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/conda-26.5.2-py314h4dc9dd8_0.conda
+  sha256: 93d639a8e56d073e286a4de48f080d71454a690213f9970bd36b4dfa1d337dd1
+  md5: 990dbd021a1325da54116f7c655664ee
   depends:
   - archspec >=0.2.3
   - boltons >=23.0.0
@@ -5038,13 +5035,12 @@ packages:
   - truststore >=0.8.0
   - zstandard >=0.19.0
   constrains:
-  - conda-content-trust >=0.3.0
-  - conda-env >=2.6
   - conda-build >=25.9
+  - conda-env >=2.6
+  - conda-content-trust >=0.3.0
   license: BSD-3-Clause
-  license_family: BSD
-  size: 1357526
-  timestamp: 1778942316700
+  size: 1359857
+  timestamp: 1780392957966
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/conda-completer-0.2.0-h046cac1_0.conda
   noarch: python
   sha256: 23e157279aa11de33a42ba1107f2aa4bba5becc40ca31ac5ce213c29f6ffa295
@@ -5824,9 +5820,9 @@ packages:
   license_family: MIT
   size: 294731
   timestamp: 1761203441365
-- conda: https://conda.anaconda.org/conda-forge/win-64/conda-26.5.0-py314h86ab7b2_1.conda
-  sha256: f158127339ef3bb93cde90b6fe090c3a84cd39ae9012c199f5d9d457da593976
-  md5: d6707c95c12637497a02b182e4249310
+- conda: https://conda.anaconda.org/conda-forge/win-64/conda-26.5.2-py314h86ab7b2_0.conda
+  sha256: 4d43dd648cccf5d1411ea0641c94ee795ba131eb78655b070e366b587a0dc6ae
+  md5: 9bb85d99650cf4282062856e532a309b
   depends:
   - archspec >=0.2.3
   - boltons >=23.0.0
@@ -5854,13 +5850,12 @@ packages:
   - truststore >=0.8.0
   - zstandard >=0.19.0
   constrains:
-  - conda-build >=25.9
   - conda-content-trust >=0.3.0
   - conda-env >=2.6
+  - conda-build >=25.9
   license: BSD-3-Clause
-  license_family: BSD
-  size: 1355837
-  timestamp: 1778942143361
+  size: 1357863
+  timestamp: 1780392812263
 - conda: https://conda.anaconda.org/conda-forge/win-64/conda-completer-0.2.0-hc05bbc4_0.conda
   noarch: python
   sha256: 3283feb2674ab35e4ef39ca716539a23c59617e01cf60550ac56938e8c46859a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "conda-express"
-version = "26.5.0"
+version = "26.5.2"
 description = "A lightweight, single-binary conda bootstrapper"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -83,7 +83,7 @@ docs-clean = { cmd = "rm -rf _build", cwd = "docs" }
 
 [tool.pixi.feature.runtime.dependencies]
 python = ">=3.12"
-conda = "==26.5.0"
+conda = "==26.5.2"
 conda-rattler-solver = "*"
 conda-spawn = ">=0.1.0"
 conda-completion = ">=0.2.0"

--- a/scripts/get-cx.ps1
+++ b/scripts/get-cx.ps1
@@ -28,7 +28,7 @@
 .EXAMPLE
     irm https://jezdez.github.io/conda-express/get-cx.ps1 | iex
 .EXAMPLE
-    & { $Version = "26.5.0"; irm https://jezdez.github.io/conda-express/get-cx.ps1 | iex }
+    & { $Version = "26.5.2"; irm https://jezdez.github.io/conda-express/get-cx.ps1 | iex }
 .LINK
     https://github.com/jezdez/conda-express
 #>


### PR DESCRIPTION
## Summary

- Bump conda-express and the pinned runtime conda package to 26.5.2.
- Refresh release notes, docs, installer examples, and release workflow messaging for 26.5.2.
- Keep the Pixi runtime lock aligned with the updated package metadata.

## Validation

- `pixi lock`
- `pixi run -e docs docs`
- `pixi run security`