### PR TITLE
Date 26.5.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 26.5.2 (unreleased)
+## 26.5.2 (2026-06-03)
 
 ### Versioning
 


### PR DESCRIPTION
## Summary

- Mark the 26.5.2 changelog entry as released on 2026-06-03 instead of unreleased.

## Validation

- `pixi run -e docs docs`