### PR TITLE
Use setuptools-scm for package versioning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,12 +107,14 @@ jobs:
           EXPECTED_RUNTIME: ${{ matrix.variant }}
           SMOKE_PREFIX: ${{ runner.temp }}/${{ matrix.variant }}-smoke
         run: |
-          EXPECTED_VERSION="$(sed -n 's/^version = "\([^"]*\)"/\1/p' pyproject.toml | head -n1)"
           ACTUAL_VERSION="$("$BINARY_PATH" --version)"
-          if [ "$ACTUAL_VERSION" != "$EXPECTED_RUNTIME $EXPECTED_VERSION" ]; then
-            echo "expected $EXPECTED_RUNTIME $EXPECTED_VERSION, got $ACTUAL_VERSION" >&2
-            exit 1
-          fi
+          case "$ACTUAL_VERSION" in
+            "$EXPECTED_RUNTIME "[0-9]*) ;;
+            *)
+              echo "expected $EXPECTED_RUNTIME version, got $ACTUAL_VERSION" >&2
+              exit 1
+              ;;
+          esac
           "$BINARY_PATH" --path "$SMOKE_PREFIX" bootstrap
           "$BINARY_PATH" --path "$SMOKE_PREFIX" status
           "$BINARY_PATH" --path "$SMOKE_PREFIX" completion --help | grep -q "Generate and install shell tab completions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,12 +143,14 @@ jobs:
           EXPECTED_RUNTIME: ${{ matrix.variant }}
           SMOKE_PREFIX: ${{ runner.temp }}/${{ matrix.variant }}-smoke
         run: |
-          EXPECTED_VERSION="$(sed -n 's/^version = "\([^"]*\)"/\1/p' pyproject.toml | head -n1)"
           ACTUAL_VERSION="$("$BINARY_PATH" --version)"
-          if [ "$ACTUAL_VERSION" != "$EXPECTED_RUNTIME $EXPECTED_VERSION" ]; then
-            echo "expected $EXPECTED_RUNTIME $EXPECTED_VERSION, got $ACTUAL_VERSION" >&2
-            exit 1
-          fi
+          case "$ACTUAL_VERSION" in
+            "$EXPECTED_RUNTIME "[0-9]*) ;;
+            *)
+              echo "expected $EXPECTED_RUNTIME version, got $ACTUAL_VERSION" >&2
+              exit 1
+              ;;
+          esac
           "$BINARY_PATH" --path "$SMOKE_PREFIX" bootstrap
           "$BINARY_PATH" --path "$SMOKE_PREFIX" status
           "$BINARY_PATH" --path "$SMOKE_PREFIX" completion --help | grep -q "Generate and install shell tab completions"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,17 +51,6 @@ jobs:
           ref: refs/tags/${{ steps.release.outputs.tag }}
           persist-credentials: false
 
-      - name: Verify package version
-        shell: bash
-        env:
-          RELEASE_VERSION: ${{ steps.release.outputs.version }}
-        run: |
-          PYPROJECT_VERSION="$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
-          if [ "$PYPROJECT_VERSION" != "$RELEASE_VERSION" ]; then
-            echo "pyproject.toml version $PYPROJECT_VERSION does not match release tag $RELEASE_VERSION" >&2
-            exit 1
-          fi
-
   build-binaries:
     name: Build ${{ matrix.variant }} (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
@@ -157,9 +146,9 @@ jobs:
         env:
           BINARY_PATH: ${{ steps.build.outputs.binary-path }}
           EXPECTED_RUNTIME: ${{ matrix.variant }}
+          EXPECTED_VERSION: ${{ needs.validate-release.outputs.version }}
           SMOKE_PREFIX: ${{ runner.temp }}/${{ matrix.variant }}-smoke
         run: |
-          EXPECTED_VERSION="$(sed -n 's/^version = "\([^"]*\)"/\1/p' pyproject.toml | head -n1)"
           ACTUAL_VERSION="$("$BINARY_PATH" --version)"
           if [ "$ACTUAL_VERSION" != "$EXPECTED_RUNTIME $EXPECTED_VERSION" ]; then
             echo "expected $EXPECTED_RUNTIME $EXPECTED_VERSION, got $ACTUAL_VERSION" >&2
@@ -214,6 +203,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: refs/tags/${{ needs.validate-release.outputs.tag }}
+          fetch-depth: 0
           persist-credentials: false
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -221,22 +211,12 @@ jobs:
           name: ${{ matrix.asset }}
           path: binary-artifact
 
-      - name: Verify package version
-        shell: bash
-        env:
-          RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
-        run: |
-          PYPROJECT_VERSION="$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
-          if [ "$PYPROJECT_VERSION" != "$RELEASE_VERSION" ]; then
-            echo "pyproject.toml version $PYPROJECT_VERSION does not match release tag $RELEASE_VERSION" >&2
-            exit 1
-          fi
-
       - name: Build wheel from conda-ship-built binary
         shell: bash
         env:
           ASSET_NAME: ${{ matrix.asset }}
           PLATFORM_TAG: ${{ matrix.platform-tag }}
+          RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
         run: |
           mkdir -p python/conda_express/bin
           if [[ "$ASSET_NAME" == *.exe ]]; then
@@ -248,6 +228,13 @@ jobs:
           python3 -m pip wheel --no-deps --wheel-dir dist . \
             --config-settings=--build-option=--plat-name \
             --config-settings=--build-option="${PLATFORM_TAG}"
+          shopt -s nullglob
+          wheels=(dist/*.whl)
+          if [ "${#wheels[@]}" -ne 1 ]; then
+            echo "Expected one wheel, found ${#wheels[@]}" >&2
+            exit 1
+          fi
+          unzip -p "${wheels[0]}" "*/METADATA" | grep -Fx "Version: ${RELEASE_VERSION}"
 
       - name: Attest wheel
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=82.0.1", "wheel"]
+requires = ["setuptools>=82.0.1", "setuptools-scm[toml]>=8.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "conda-express"
-version = "26.5.2"
+dynamic = ["version"]
 description = "A lightweight, single-binary conda bootstrapper"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -38,8 +38,13 @@ include-package-data = true
 [tool.setuptools.package-data]
 conda_express = ["py.typed", "bin/cx", "bin/cx.exe"]
 
+[tool.setuptools_scm]
+version_scheme = "no-guess-dev"
+local_scheme = "no-local-version"
+
 [tool.conda-ship]
 runtime = "cx"
+runtime-version = "26.5.2"
 delegate = "conda"
 layout = "online"
 source-environment = "runtime"


### PR DESCRIPTION
## Summary

- Switch Python package metadata from a static `project.version` to `setuptools_scm` dynamic versioning.
- Keep setuptools as the build backend so release wheels can continue using setuptools' platform tag build option.
- Store the conda-ship runtime version in `[tool.conda-ship].runtime-version` so workflows do not parse `pyproject.toml` or call a helper script.
- Keep release checks comparing binary and wheel versions against the release tag.

## Validation

- Temp wheel build with `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CONDA_EXPRESS=26.5.2`
- `pixi lock --check`
- `pixi run -e docs docs`
- `pixi run security`