### PR TITLE
Update conda-ship to 0.2.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Build ${{ matrix.variant }}
         id: build
-        uses: jezdez/conda-ship@0.1.0 # zizmor: ignore[unpinned-uses] conda-ship immutable releases keep the action and assets aligned.
+        uses: jezdez/conda-ship@0.2.1 # zizmor: ignore[unpinned-uses] conda-ship immutable releases keep the action and assets aligned.
         with:
           layout: ${{ matrix.layout }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Build ${{ matrix.variant }}
         id: build
-        uses: jezdez/conda-ship@0.1.0 # zizmor: ignore[unpinned-uses] conda-ship immutable releases keep the action and assets aligned.
+        uses: jezdez/conda-ship@0.2.1 # zizmor: ignore[unpinned-uses] conda-ship immutable releases keep the action and assets aligned.
         with:
           layout: ${{ matrix.layout }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
 
       - name: Build ${{ matrix.variant }}
         id: build
-        uses: jezdez/conda-ship@0.1.0 # zizmor: ignore[unpinned-uses] conda-ship immutable releases keep the action and assets aligned.
+        uses: jezdez/conda-ship@0.2.1 # zizmor: ignore[unpinned-uses] conda-ship immutable releases keep the action and assets aligned.
         with:
           layout: ${{ matrix.layout }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 
 - Build the published `cx` and `cxz` runtime binaries with conda-ship instead
   of the old repository-local Rust builder.
+- Build with conda-ship `0.2.1` and derive the generated runtime version from
+  project metadata, so release tags drive both the Python package version and
+  the stamped binary version.
 - Keep conda-express focused on the `cx` / `cxz` distribution.
   Custom runtime builds now belong in conda-ship.
 - Continue publishing GitHub Release artifacts, installer scripts, Docker

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ committed lockfile:
 ```toml
 [tool.conda-ship]
 runtime = "cx"
+runtime-version = { from = "project-metadata" }
 delegate = "conda"
 layout = "online"
 source-environment = "runtime"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,7 @@ runtime:
 ```toml
 [tool.conda-ship]
 runtime = "cx"
+runtime-version = { from = "project-metadata" }
 delegate = "conda"
 layout = "online"
 source-environment = "runtime"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ local_scheme = "no-local-version"
 
 [tool.conda-ship]
 runtime = "cx"
-runtime-version = "26.5.2"
+runtime-version = { from = "project-metadata" }
 delegate = "conda"
 layout = "online"
 source-environment = "runtime"


### PR DESCRIPTION
## Summary

- Update conda-express workflows to use `jezdez/conda-ship@0.2.1`.
- Switch `[tool.conda-ship].runtime-version` to `{ from = "project-metadata" }` so conda-ship resolves the dynamic setuptools-scm project version.
- Update docs and changelog snippets to document the project-metadata runtime version source.

## Validation

- `pixi lock --check`
- `pixi run -e docs docs`
- `pixi run security`
- Verified `jezdez/conda-ship` release `0.2.1` exists with `cs`, `cs-template`, and `SHA256SUMS` assets.
- Verified `jezdez/conda-ship@0.2.1` resolves `runtime-version = { from = "project-metadata" }` before invoking `cs`.
