### PR TITLE
Fix Linux wheel platform tags for 26.5.2.post1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,10 +185,10 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             asset: cx-x86_64-unknown-linux-gnu
-            platform-tag: manylinux_2_17_x86_64.manylinux2014_x86_64
+            platform-tag: manylinux2014_x86_64
           - target: aarch64-unknown-linux-gnu
             asset: cx-aarch64-unknown-linux-gnu
-            platform-tag: manylinux_2_17_aarch64.manylinux2014_aarch64
+            platform-tag: manylinux2014_aarch64
           - target: x86_64-apple-darwin
             asset: cx-x86_64-apple-darwin
             platform-tag: macosx_10_12_x86_64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 26.5.2.post1 (2026-06-03)
+
+### Distribution
+
+- Rebuild the PyPI wheels with single `manylinux2014` platform tags for Linux,
+  so PyPI accepts the linux-64 and linux-aarch64 wheel uploads.
+
 ## 26.5.2 (2026-06-03)
 
 ### Versioning


### PR DESCRIPTION
## Summary

- Switch Linux PyPI wheel platform tags from compressed manylinux aliases to single `manylinux2014_*` tags.
- Add a `26.5.2.post1` changelog entry for the PyPI wheel rebuild.

## Context

The `26.5.2` release run published GitHub release assets, Homebrew, Docker images, and two macOS PyPI wheels, but PyPI rejected the Linux aarch64 wheel because setuptools emitted `manylinux_2_17_aarch64_manylinux2014_aarch64` as one unsupported platform tag.

## Validation

- `pixi lock --check`
- `pixi run -e docs docs`
- `pixi run security`
- Focused wheel filename build with `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CONDA_EXPRESS=26.5.2.post1` and `--plat-name manylinux2014_aarch64`, which produced `conda_express-26.5.2.post1-py3-none-manylinux2014_aarch64.whl`.
