### PR TITLE
Update conda-ship to 0.3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Build ${{ matrix.variant }}
         id: build
-        uses: jezdez/conda-ship@0.2.1 # zizmor: ignore[unpinned-uses] conda-ship immutable releases keep the action and assets aligned.
+        uses: jezdez/conda-ship@0.3.0 # zizmor: ignore[unpinned-uses] conda-ship immutable releases keep the action and assets aligned.
         with:
           layout: ${{ matrix.layout }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Build ${{ matrix.variant }}
         id: build
-        uses: jezdez/conda-ship@0.2.1 # zizmor: ignore[unpinned-uses] conda-ship immutable releases keep the action and assets aligned.
+        uses: jezdez/conda-ship@0.3.0 # zizmor: ignore[unpinned-uses] conda-ship immutable releases keep the action and assets aligned.
         with:
           layout: ${{ matrix.layout }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
 
       - name: Build ${{ matrix.variant }}
         id: build
-        uses: jezdez/conda-ship@0.2.1 # zizmor: ignore[unpinned-uses] conda-ship immutable releases keep the action and assets aligned.
+        uses: jezdez/conda-ship@0.3.0 # zizmor: ignore[unpinned-uses] conda-ship immutable releases keep the action and assets aligned.
         with:
           layout: ${{ matrix.layout }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Distribution
+
+- Build CI and release artifacts with conda-ship `0.3.0`.
+- Document conda-ship `0.3.0` runtime metadata, completion, and Windows ARM64
+  support boundaries.
+
 ## 26.5.2.post1 (2026-06-03)
 
 ### Distribution

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ cx completion status
 cx completion install --dry-run
 ```
 
+The generated runtime tells completion hooks to register the `cx` command name
+instead of the underlying `conda` delegate.
+
 The `conda-libmamba-solver` and its 27 exclusive native dependencies (libsolv, libarchive, libcurl, spdlog, etc.) are excluded by default because cx configures `conda-rattler-solver`.
 
 ## Versioning
@@ -116,6 +119,10 @@ Download the binary for your platform from the
 | macOS x86_64 (Intel) | `cx-x86_64-apple-darwin` |
 | macOS ARM64 (Apple Silicon) | `cx-aarch64-apple-darwin` |
 | Windows x86_64 | `cx-x86_64-pc-windows-msvc.exe` |
+
+Windows ARM64 is not published for conda-express yet. conda-ship 0.3.0
+publishes Windows ARM64 builder assets, but full runtime bootstrap support is
+still gated by the conda package ecosystem.
 
 Each file has matching `.sha256`, `.info.json`, `.packages.txt`, and
 `.runtime.lock` files. Release artifacts are also covered by GitHub Artifact
@@ -252,9 +259,17 @@ cx create -n myenv numpy pandas
 cx shell myenv
 ```
 
-For now, update the base installation by re-bootstrapping with
-`cx bootstrap --force`. The included `conda-self` plugin is intended to make
-base updates available as a conda command once that workflow has settled.
+Bootstrap also writes constructor-compatible prefix metadata:
+`conda-meta/history` and `conda-meta/initial-state.explicit.txt`. Conda can
+recognize the managed prefix as an environment, and the included `conda-self`
+plugin can use the initial-state snapshot:
+
+```bash
+cx self reset --snapshot installer-exact
+```
+
+Use `cx bootstrap --force` when you want to discard and rebuild the managed
+base prefix from the stamped runtime lock.
 
 ## Building custom binaries
 
@@ -283,7 +298,9 @@ through your original install method.
    runtime lock, filter excluded packages, and stamp that lock into the staged
    binary.
 
-2. **First run**: cx reads the stamped runtime lock, downloads packages from conda-forge, and installs them into the prefix. No repodata fetch or solve needed at runtime.
+2. **First run**: cx reads the stamped runtime lock, downloads packages from
+   conda-forge, installs them into the prefix, and writes conda-compatible
+   prefix metadata. No repodata fetch or solve needed at runtime.
 
 3. **Subsequent runs**: cx detects the existing prefix and replaces its own process with the installed `conda` binary, passing all arguments through.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,9 +49,9 @@ The `runtime` source environment installs:
 | `conda ==26.5.2` | Package manager |
 | `conda-rattler-solver` | Default solver |
 | `conda-spawn >=0.1.0` | Subshell activation |
-| `conda-completion >=0.2.0` | Shell completion |
+| `conda-completion >=0.2.0` | Shell completion for `cx` and conda plugin commands |
 | `conda-pypi` | PyPI interoperability |
-| `conda-self` | Base environment self-management |
+| `conda-self` | Base environment self-management and reset |
 | `conda-global` | Global tool environments |
 | `conda-workspaces >=0.5.0` | Workspace manifests and tasks |
 
@@ -102,6 +102,21 @@ and prefix ownership checks.
 Generated conda-ship runtimes write ownership metadata into each managed
 install path. `cx status`, `cx bootstrap --force`, and `cx uninstall` use that
 metadata to avoid taking over or deleting unrelated conda installations.
+
+Bootstrap also writes standard conda prefix metadata:
+
+- `conda-meta/history`
+- `conda-meta/initial-state.explicit.txt`
+
+`history` lets conda recognize `~/.conda/express` as an environment. The
+initial-state file records the exact packages installed from the stamped
+runtime lock, including package URLs and checksums. The included `conda-self`
+plugin can use that snapshot to reset the managed base prefix to the shipped
+package set:
+
+```bash
+cx self reset --snapshot installer-exact
+```
 
 The managed base environment is also protected with a
 [CEP 22](https://conda.org/learn/ceps/cep-0022/) frozen marker after bootstrap.

--- a/docs/features.md
+++ b/docs/features.md
@@ -88,6 +88,10 @@ cx completion status
 cx completion install --dry-run
 ```
 
+conda-ship stamps the runtime command name into delegate environments, so the
+completion integration can register `cx` rather than the underlying `conda`
+executable.
+
 The command is optional: cx does not require shell completion, and the dry run
 lets you inspect the shell profile hook before enabling it.
 
@@ -152,6 +156,25 @@ for their work:
 cx create -n myenv numpy pandas
 cx shell myenv
 ```
+
+## Base prefix reset metadata
+
+cx also writes constructor-compatible conda prefix metadata during bootstrap:
+`conda-meta/history` and `conda-meta/initial-state.explicit.txt`. The history
+file lets conda recognize the managed prefix as an environment. The
+initial-state file records the exact package URLs and checksums from the
+stamped runtime lock.
+
+Because conda-express includes `conda-self`, that initial-state snapshot can be
+used to reset the managed base prefix to the package set shipped by the
+runtime:
+
+```bash
+cx self reset --snapshot installer-exact
+```
+
+Use `cx bootstrap --force` when you want to discard and rebuild the whole
+managed prefix from the stamped runtime lock.
 
 ## Auto-bootstrap
 
@@ -286,3 +309,8 @@ cx builds and tests on 5 platforms via GitHub Actions:
 | macos-x64 | `macos-15-intel` |
 | macos-arm64 | `macos-15` |
 | windows-x64 | `windows-latest` |
+
+conda-ship 0.3.0 publishes Windows ARM64 builder assets and maps
+`Windows`/`ARM64` action runners to `aarch64-pc-windows-msvc`. conda-express
+does not publish Windows ARM64 `cx` or `cxz` artifacts yet because full runtime
+bootstrap support still depends on the conda package ecosystem.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -77,6 +77,10 @@ Download the binary for your platform from the
 | macOS ARM64 (Apple Silicon) | `cx-aarch64-apple-darwin` | `cxz-aarch64-apple-darwin` |
 | Windows x86_64 | `cx-x86_64-pc-windows-msvc.exe` | `cxz-x86_64-pc-windows-msvc.exe` |
 
+Windows ARM64 is not published for conda-express yet. conda-ship has Windows
+ARM64 builder assets, but full runtime bootstrap support still depends on the
+conda package ecosystem.
+
 Each runtime has matching `.sha256`, `.info.json`, `.packages.txt`, and
 `.runtime.lock` metadata. Direct downloads are also covered by GitHub Artifact
 Attestations from the release workflow. For a quick attestation check:
@@ -156,7 +160,10 @@ cx bootstrap
 Bootstrap uses the built-in runtime lock, so it does not solve an environment
 at runtime. The prefix is protected with a
 [CEP 22](https://conda.org/learn/ceps/cep-0022/) frozen marker to prevent
-accidental modification.
+accidental modification. Bootstrap also writes `conda-meta/history` and
+`conda-meta/initial-state.explicit.txt`, so conda recognizes the managed
+prefix as an environment and `conda-self` can reset it to the shipped package
+set.
 
 ## Set up your PATH
 
@@ -224,11 +231,12 @@ To update the base conda installation, re-bootstrap:
 cx bootstrap --force
 ```
 
-:::{note}
-The included `conda-self` plugin is intended to make base updates available as
-a conda command once that workflow has settled. Until then, use
-`cx bootstrap --force`.
-:::
+To reset the existing managed base prefix to the package set shipped by the
+runtime, use the `conda-self` snapshot written during bootstrap:
+
+```bash
+cx self reset --snapshot installer-exact
+```
 
 ## Uninstalling
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -63,6 +63,13 @@ cx bootstrap [OPTIONS]
   from the local package cache, `--bundle`, or an embedded `cxz` bundle. Can
   also be set via `CX_OFFLINE`.
 
+After package installation, bootstrap writes conda-ship ownership metadata,
+`.condarc`, the CEP 22 frozen marker, and standard conda prefix metadata in
+`conda-meta/history` and `conda-meta/initial-state.explicit.txt`. The
+initial-state file records the package URLs and checksums from the stamped
+runtime lock so `conda-self` can reset the managed base prefix to the shipped
+package set.
+
 :::{note}
 `cxz` is the embedded-bundle variant. It detects its embedded package bundle
 automatically, so `--bundle` is not needed. Use `--offline` when you want the
@@ -189,6 +196,7 @@ cx list -n myenv
 cx env list
 cx config --show
 cx self update
+cx self reset --snapshot installer-exact
 ```
 
 Use global runtime options before the pass-through command:

--- a/docs/reference/included-plugins.md
+++ b/docs/reference/included-plugins.md
@@ -12,7 +12,7 @@ behavior.
 | `conda-spawn` | Subprocess-based activation | `cx shell ENV`, `conda spawn ENV` |
 | `conda-completion` | Shell completion support | `cx completion status`, `cx completion install --dry-run` |
 | `conda-pypi` | PyPI interoperability inside conda workflows | PyPI dependency handling through the conda plugin stack |
-| `conda-self` | Base environment self-management workflow | `cx self ...`, `conda self ...` |
+| `conda-self` | Base environment self-management workflow | `cx self reset --snapshot installer-exact` |
 | `conda-global` | Isolated global tool environments | `cx global install ruff`, `cx global list` |
 | `conda-workspaces` | Project workspaces, tasks, and lockfiles | `cx workspace ...`, `cx task ...` |
 
@@ -27,8 +27,8 @@ turning the base prefix into a project environment:
 - `conda-rattler-solver` avoids libmamba's native dependency chain in the
   managed base.
 - `conda-spawn` gives users an activation workflow without `conda init`.
-- `conda-self` provides the plugin surface for managed base-prefix updates as
-  that workflow settles.
+- `conda-self` can reset the managed base prefix from the initial-state
+  snapshot written at bootstrap.
 - `conda-global` covers isolated command-line tools.
 - `conda-workspaces` covers project-level environments and tasks for users who
   want a conda-native workspace workflow.
@@ -48,6 +48,10 @@ cx completion install --dry-run
 that enables command completion for conda commands and installed conda plugin
 subcommands. Use `--dry-run` first to inspect the profile changes before
 writing them.
+
+conda-ship sets the runtime command name for delegate environments, so the
+completion hook can register `cx` rather than the underlying `conda`
+executable.
 
 ## Activation Workflow
 

--- a/docs/reference/installer.md
+++ b/docs/reference/installer.md
@@ -133,7 +133,9 @@ The PowerShell script uses .NET's `RuntimeInformation.OSArchitecture`.
 | macOS ARM64 | `aarch64-apple-darwin` | `cx-aarch64-apple-darwin` |
 | Windows x86_64 | `x86_64-pc-windows-msvc` | `cx-x86_64-pc-windows-msvc.exe` |
 
-Windows ARM64 is not published yet; the PowerShell installer reports that
+Windows ARM64 is not published for conda-express yet. conda-ship 0.3.0 has
+Windows ARM64 builder assets, but full runtime bootstrap support still depends
+on the conda package ecosystem. The PowerShell installer reports that
 architecture as unsupported instead of downloading an incompatible binary.
 
 ## Shell profile updates


### PR DESCRIPTION
## Summary

- update the build, CI, and release workflows to use `jezdez/conda-ship@0.3.0`
- document conda-ship 0.3.0 runtime behavior in the conda-express docs
- add an Unreleased changelog entry for the conda-ship bump and docs alignment

## Why

`conda-ship` 0.3.0 is the latest immutable release, so conda-express CI and release artifacts should use the matching action and release assets. The docs also need to reflect the runtime behavior introduced in 0.3.0: constructor-compatible prefix metadata, `conda-self` reset snapshots, completion command-name handling, and the current Windows ARM64 support boundary.

## Impact

Future CI and release builds of `cx` and `cxz` will run through conda-ship 0.3.0. User-facing docs now describe the prefix metadata written at bootstrap, the `cx self reset --snapshot installer-exact` path, and that conda-express still does not publish Windows ARM64 runtimes even though conda-ship has Windows ARM64 builder assets. No Pixi metadata changed, so `pixi.lock` was not regenerated.

## Validation

- `pixi run security`
- `pixi run -e docs docs`

## Reference

- https://github.com/jezdez/conda-ship/releases/tag/0.3.0