### PR TITLE
Prepare conda-express 26.5.2.post2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 26.5.2.post2 (2026-06-11)
 
 ### Distribution
 


### PR DESCRIPTION
## Summary

- move the conda-ship 0.3.0 changelog notes from Unreleased to `26.5.2.post2`
- bump the conda-express build/post-release number from `26.5.2.post1` to `26.5.2.post2`

## Notes

The runtime conda package remains `26.5.2`, so no Pixi metadata or lockfile update is needed. The actual release version is derived from the eventual `26.5.2.post2` tag via setuptools-scm.

The Homebrew formula is not updated in this PR because the release workflow updates it after publishing release assets and checksums.

## Validation

- `pixi run -e docs docs`
- `pixi run security`