### PR TITLE
Update conda-ship integration for 0.4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,43 +27,43 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             variant: cx
-            layout: online
+            artifact_layout: online
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
             variant: cx
-            layout: online
+            artifact_layout: online
           - target: x86_64-apple-darwin
             os: macos-15-intel
             variant: cx
-            layout: online
+            artifact_layout: online
           - target: aarch64-apple-darwin
             os: macos-15
             variant: cx
-            layout: online
+            artifact_layout: online
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             variant: cx
-            layout: online
+            artifact_layout: online
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             variant: cxz
-            layout: embedded
+            artifact_layout: embedded
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
             variant: cxz
-            layout: embedded
+            artifact_layout: embedded
           - target: x86_64-apple-darwin
             os: macos-15-intel
             variant: cxz
-            layout: embedded
+            artifact_layout: embedded
           - target: aarch64-apple-darwin
             os: macos-15
             variant: cxz
-            layout: embedded
+            artifact_layout: embedded
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             variant: cxz
-            layout: embedded
+            artifact_layout: embedded
 
     steps:
       - name: Verify matrix target
@@ -96,9 +96,11 @@ jobs:
 
       - name: Build ${{ matrix.variant }}
         id: build
-        uses: jezdez/conda-ship@0.3.0 # zizmor: ignore[unpinned-uses] conda-ship immutable releases keep the action and assets aligned.
+        uses: jezdez/conda-ship@15cf30a3fbf79731704737ea563c22de74d63b41 # 0.4.0
         with:
-          layout: ${{ matrix.layout }}
+          conda-ship-version: "0.4.0"
+          artifact-layout: ${{ matrix.artifact_layout }}
+          artifact-name: ${{ matrix.variant }}
 
       - name: Smoke test ${{ matrix.variant }}
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,43 +118,43 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             variant: cx
-            layout: online
+            artifact_layout: online
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
             variant: cx
-            layout: online
+            artifact_layout: online
           - target: x86_64-apple-darwin
             os: macos-15-intel
             variant: cx
-            layout: online
+            artifact_layout: online
           - target: aarch64-apple-darwin
             os: macos-15
             variant: cx
-            layout: online
+            artifact_layout: online
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             variant: cx
-            layout: online
+            artifact_layout: online
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             variant: cxz
-            layout: embedded
+            artifact_layout: embedded
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
             variant: cxz
-            layout: embedded
+            artifact_layout: embedded
           - target: x86_64-apple-darwin
             os: macos-15-intel
             variant: cxz
-            layout: embedded
+            artifact_layout: embedded
           - target: aarch64-apple-darwin
             os: macos-15
             variant: cxz
-            layout: embedded
+            artifact_layout: embedded
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             variant: cxz
-            layout: embedded
+            artifact_layout: embedded
 
     steps:
       - name: Verify matrix target
@@ -187,9 +187,11 @@ jobs:
 
       - name: Build ${{ matrix.variant }}
         id: build
-        uses: jezdez/conda-ship@0.3.0 # zizmor: ignore[unpinned-uses] conda-ship immutable releases keep the action and assets aligned.
+        uses: jezdez/conda-ship@15cf30a3fbf79731704737ea563c22de74d63b41 # 0.4.0
         with:
-          layout: ${{ matrix.layout }}
+          conda-ship-version: "0.4.0"
+          artifact-layout: ${{ matrix.artifact_layout }}
+          artifact-name: ${{ matrix.variant }}
 
       - name: Smoke test ${{ matrix.variant }}
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,43 +67,43 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             variant: cx
-            layout: online
+            artifact_layout: online
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
             variant: cx
-            layout: online
+            artifact_layout: online
           - target: x86_64-apple-darwin
             os: macos-15-intel
             variant: cx
-            layout: online
+            artifact_layout: online
           - target: aarch64-apple-darwin
             os: macos-15
             variant: cx
-            layout: online
+            artifact_layout: online
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             variant: cx
-            layout: online
+            artifact_layout: online
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             variant: cxz
-            layout: embedded
+            artifact_layout: embedded
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
             variant: cxz
-            layout: embedded
+            artifact_layout: embedded
           - target: x86_64-apple-darwin
             os: macos-15-intel
             variant: cxz
-            layout: embedded
+            artifact_layout: embedded
           - target: aarch64-apple-darwin
             os: macos-15
             variant: cxz
-            layout: embedded
+            artifact_layout: embedded
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             variant: cxz
-            layout: embedded
+            artifact_layout: embedded
 
     steps:
       - name: Verify matrix target
@@ -137,9 +137,11 @@ jobs:
 
       - name: Build ${{ matrix.variant }}
         id: build
-        uses: jezdez/conda-ship@0.3.0 # zizmor: ignore[unpinned-uses] conda-ship immutable releases keep the action and assets aligned.
+        uses: jezdez/conda-ship@15cf30a3fbf79731704737ea563c22de74d63b41 # 0.4.0
         with:
-          layout: ${{ matrix.layout }}
+          conda-ship-version: "0.4.0"
+          artifact-layout: ${{ matrix.artifact_layout }}
+          artifact-name: ${{ matrix.variant }}
 
       - name: Smoke test ${{ matrix.variant }} release binary
         shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,9 +25,9 @@
 - Minimize the dependency graph. Prefer existing Pixi dependencies and
   GitHub Actions over adding new tooling.
 
-- Use exact SHAs for GitHub Actions in CI workflows. The conda-ship action is
-  the exception: use its immutable release tag so the action and downloaded
-  release assets share the same version.
+- Use exact SHAs for GitHub Actions in CI workflows. For the conda-ship action,
+  pin the action source to the release commit SHA and pass the matching
+  `conda-ship-version` input so downloaded release assets stay aligned.
 
 ## Typing and linting
 

--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ Download the binary for your platform from the
 | macOS ARM64 (Apple Silicon) | `cx-aarch64-apple-darwin` |
 | Windows x86_64 | `cx-x86_64-pc-windows-msvc.exe` |
 
-Windows ARM64 is not published for conda-express yet. conda-ship 0.3.0
-publishes Windows ARM64 builder assets, but full runtime bootstrap support is
-still gated by the conda package ecosystem.
+Windows ARM64 is not published for conda-express yet. conda-ship publishes
+Windows ARM64 builder assets, but full runtime bootstrap support is still gated
+by the conda package ecosystem.
 
 Each file has matching `.sha256`, `.info.json`, `.packages.txt`, and
 `.runtime.lock` files. Release artifacts are also covered by GitHub Artifact
@@ -245,12 +245,12 @@ committed lockfile:
 
 ```toml
 [tool.conda-ship]
-runtime = "cx"
+runtime-name = "cx"
 runtime-version = { from = "project-metadata" }
-delegate = "conda"
-layout = "online"
+delegate-executable = "conda"
+artifact-layout = "online"
 source-environment = "runtime"
-exclude = ["conda-libmamba-solver"]
+exclude-packages = ["conda-libmamba-solver"]
 docs-url = "https://jezdez.github.io/conda-express/"
 install-scheme = "conda-home"
 install-name = "express"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,21 +10,21 @@ runtime:
 
 ```toml
 [tool.conda-ship]
-runtime = "cx"
+runtime-name = "cx"
 runtime-version = { from = "project-metadata" }
-delegate = "conda"
-layout = "online"
+delegate-executable = "conda"
+artifact-layout = "online"
 source-environment = "runtime"
-exclude = ["conda-libmamba-solver"]
+exclude-packages = ["conda-libmamba-solver"]
 docs-url = "https://jezdez.github.io/conda-express/"
 install-scheme = "conda-home"
 install-name = "express"
 ```
 
-The release workflows override only `layout`:
+The release workflows override `artifact-layout` and `artifact-name`:
 
-- `layout = "online"` builds `cx`
-- `layout = "embedded"` builds `cxz`
+- `artifact-layout = "online"` with `artifact-name = "cx"` builds `cx`
+- `artifact-layout = "embedded"` with `artifact-name = "cxz"` builds `cxz`
 
 The source environment is solved and locked by Pixi. conda-ship derives the
 runtime lock from that committed source lock rather than accepting ad hoc

--- a/docs/features.md
+++ b/docs/features.md
@@ -331,7 +331,7 @@ cx builds and tests on 5 platforms via GitHub Actions:
 | macos-arm64 | `macos-15` |
 | windows-x64 | `windows-latest` |
 
-conda-ship 0.3.0 publishes Windows ARM64 builder assets and maps
-`Windows`/`ARM64` action runners to `aarch64-pc-windows-msvc`. conda-express
-does not publish Windows ARM64 `cx` or `cxz` artifacts yet because full runtime
-bootstrap support still depends on the conda package ecosystem.
+conda-ship publishes Windows ARM64 builder assets and maps `Windows`/`ARM64`
+action runners to `aarch64-pc-windows-msvc`. conda-express does not publish
+Windows ARM64 `cx` or `cxz` artifacts yet because full runtime bootstrap
+support still depends on the conda package ecosystem.

--- a/docs/reference/installer.md
+++ b/docs/reference/installer.md
@@ -183,10 +183,10 @@ The PowerShell script uses .NET's `RuntimeInformation.OSArchitecture`.
 | macOS ARM64 | `aarch64-apple-darwin` | `cx-aarch64-apple-darwin` |
 | Windows x86_64 | `x86_64-pc-windows-msvc` | `cx-x86_64-pc-windows-msvc.exe` |
 
-Windows ARM64 is not published for conda-express yet. conda-ship 0.3.0 has
-Windows ARM64 builder assets, but full runtime bootstrap support still depends
-on the conda package ecosystem. The PowerShell installer reports that
-architecture as unsupported instead of downloading an incompatible binary.
+Windows ARM64 is not published for conda-express yet. conda-ship has Windows
+ARM64 builder assets, but full runtime bootstrap support still depends on the
+conda package ecosystem. The PowerShell installer reports that architecture as
+unsupported instead of downloading an incompatible binary.
 
 ## Shell profile updates
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,12 +43,12 @@ version_scheme = "no-guess-dev"
 local_scheme = "no-local-version"
 
 [tool.conda-ship]
-runtime = "cx"
+runtime-name = "cx"
 runtime-version = { from = "project-metadata" }
-delegate = "conda"
-layout = "online"
+delegate-executable = "conda"
+artifact-layout = "online"
 source-environment = "runtime"
-exclude = ["conda-libmamba-solver"]
+exclude-packages = ["conda-libmamba-solver"]
 docs-url = "https://jezdez.github.io/conda-express/"
 install-scheme = "conda-home"
 install-name = "express"


### PR DESCRIPTION
## Summary

- update conda-ship configuration keys for the 0.4.0 flat naming scheme
- pin conda-ship action call sites to the 0.4.0 release commit SHA and pass `conda-ship-version: "0.4.0"` for matching release assets
- pass `artifact-name: ${{ matrix.variant }}` so embedded builds continue publishing `cxz-*` artifacts after 0.4.0 stopped appending `z` automatically
- use `artifact_layout` matrix fields while keeping the action input as `artifact-layout`
- refresh docs and README snippets for the renamed options

## Validation

- `pixi run security`
- `pixi run -e docs docs`
- `../conda-ship/target/release/cs inspect --root .`
- `../conda-ship/target/release/cs build --root . --target aarch64-apple-darwin --target-label aarch64-apple-darwin --template ../conda-ship/target/release/cs-template --runtime-version 0.0.0 --artifact-layout online --artifact-name cx --dry-run`
- `../conda-ship/target/release/cs build --root . --target aarch64-apple-darwin --target-label aarch64-apple-darwin --template ../conda-ship/target/release/cs-template --runtime-version 0.0.0 --artifact-layout embedded --artifact-name cxz --dry-run`
