### PR TITLE
Link included packages in README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -536,7 +536,7 @@ jobs:
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
 
-      - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+      - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ghcr.io/${{ github.repository }}@${{ steps.build.outputs.digest }}
           format: table

--- a/README.md
+++ b/README.md
@@ -38,15 +38,15 @@ cx installs a managed conda stack from conda-forge:
 
 | Package | Role |
 |---|---|
-| python >= 3.12 | Runtime |
-| conda | Package manager |
-| conda-rattler-solver | Rust-based solver without libmamba's native dependency chain |
-| conda-spawn >= 0.1.0 | Subprocess-based environment activation |
-| conda-completion >= 0.3.0 | Shell completion support |
+| [python](https://docs.python.org/3/) >= 3.12 | Runtime |
+| [conda](https://docs.conda.io/projects/conda/en/stable/) | Package manager |
+| [conda-rattler-solver](https://github.com/conda/conda-rattler-solver) | Rust-based solver without libmamba's native dependency chain |
+| [conda-spawn](https://conda.github.io/conda-spawn/) >= 0.1.0 | Subprocess-based environment activation |
+| [conda-completion](https://conda-incubator.github.io/conda-completion/) >= 0.3.0 | Shell completion support |
 | [conda-exec](https://conda-incubator.github.io/conda-exec/) >= 0.3.0 | Ephemeral package execution and PEP 723 script workflows |
-| conda-pypi | PyPI interoperability |
-| conda-self | Base environment self-management |
-| conda-global | Global tool installation and PATH management |
+| [conda-pypi](https://conda.github.io/conda-pypi/) | PyPI interoperability |
+| [conda-self](https://conda.github.io/conda-self/) | Base environment self-management |
+| [conda-global](https://conda-incubator.github.io/conda-global/) | Global tool installation and PATH management |
 | [conda-workspaces](https://conda-incubator.github.io/conda-workspaces/) >= 0.7.0 | Multi-environment workspace and task management |
 
 See the [included plugins reference](https://jezdez.github.io/conda-express/reference/included-plugins/)


### PR DESCRIPTION
## Summary
- Link each runtime package in the README package table to its docs or repository
- Correct the Trivy action pin comment from `0.36.0` to `v0.36.0` so zizmor can resolve the pinned tag

## Validation
- `pixi run -e docs docs`
- `pixi run security`