### PR TITLE
Delay Homebrew update until release jobs finish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -311,7 +311,7 @@ jobs:
   update-homebrew:
     name: Update Homebrew formula
     runs-on: ubuntu-latest
-    needs: [validate-release, github-release]
+    needs: [validate-release, github-release, publish-pypi, docker-images]
     permissions:
       contents: write # commit the generated Homebrew formula update back to main
     steps:


### PR DESCRIPTION
## Summary
- Make the Homebrew formula update wait for PyPI publication and Docker image publication before committing back to main
- Keep the GitHub release asset publication as the source for checksum downloads

## Validation
- `pixi run security`