### PR TITLE
Fix installer checksum manifest handling

### DIFF
--- a/.github/actions/setup-cx/dist/index.js
+++ b/.github/actions/setup-cx/dist/index.js
@@ -34708,11 +34708,12 @@ async function main() {
 
   const baseUrl = `https://github.com/${repository}/releases/download/${resolvedVersion}`;
   const assetPath = node_path__WEBPACK_IMPORTED_MODULE_6__.join(workDir, asset.name);
-  const checksumPath = node_path__WEBPACK_IMPORTED_MODULE_6__.join(workDir, `${asset.name}.sha256`);
+  const checksumName = `${asset.name.replace(/[.]exe$/, "")}.sha256`;
+  const checksumPath = node_path__WEBPACK_IMPORTED_MODULE_6__.join(workDir, checksumName);
 
   (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq)(`Downloading ${asset.name} from conda-express ${resolvedVersion}`);
   await downloadFile(`${baseUrl}/${asset.name}`, assetPath);
-  await downloadFile(`${baseUrl}/${asset.name}.sha256`, checksumPath);
+  await downloadFile(`${baseUrl}/${checksumName}`, checksumPath);
   await verifyChecksum(assetPath, checksumPath, asset.name);
 
   if (options.verifyAttestation) {

--- a/.github/actions/setup-cx/src/index.js
+++ b/.github/actions/setup-cx/src/index.js
@@ -35,11 +35,12 @@ async function main() {
 
   const baseUrl = `https://github.com/${repository}/releases/download/${resolvedVersion}`;
   const assetPath = path.join(workDir, asset.name);
-  const checksumPath = path.join(workDir, `${asset.name}.sha256`);
+  const checksumName = `${asset.name.replace(/[.]exe$/, "")}.sha256`;
+  const checksumPath = path.join(workDir, checksumName);
 
   info(`Downloading ${asset.name} from conda-express ${resolvedVersion}`);
   await downloadFile(`${baseUrl}/${asset.name}`, assetPath);
-  await downloadFile(`${baseUrl}/${asset.name}.sha256`, checksumPath);
+  await downloadFile(`${baseUrl}/${checksumName}`, checksumPath);
   await verifyChecksum(assetPath, checksumPath, asset.name);
 
   if (options.verifyAttestation) {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           HOME: ${{ runner.temp }}/setup-cx-default-home
           CX_PREFIX: ${{ runner.temp }}/setup-cx-default-home/.conda/express
         with:
-          version: 26.5.2.post2
+          version: 26.5.2.post5
       - name: Smoke test default action path
         shell: bash
         env:
@@ -74,8 +74,8 @@ jobs:
           HOME: ${{ runner.temp }}/setup-cx-default-home
         run: |
           set -euo pipefail
-          if [ "$EXPECTED_VERSION" != "26.5.2.post2" ]; then
-            echo "expected resolved version 26.5.2.post2, got ${EXPECTED_VERSION}" >&2
+          if [ "$EXPECTED_VERSION" != "26.5.2.post5" ]; then
+            echo "expected resolved version 26.5.2.post5, got ${EXPECTED_VERSION}" >&2
             exit 1
           fi
           "$CX_PATH" info --json > "$RUNNER_TEMP/setup-cx-info.json"
@@ -92,7 +92,7 @@ jobs:
           HOME: ${{ runner.temp }}/setup-cx-no-bootstrap-home
           CX_PREFIX: ${{ runner.temp }}/setup-cx-no-bootstrap-home/.conda/express
         with:
-          version: 26.5.2.post2
+          version: 26.5.2.post5
           github-token: ${{ github.token }}
           verify-attestation: true
           add-to-path: false
@@ -105,12 +105,59 @@ jobs:
           EXPECTED_VERSION: ${{ steps.setup-cx-attested.outputs.version }}
         run: |
           set -euo pipefail
-          if [ "$EXPECTED_VERSION" != "26.5.2.post2" ]; then
-            echo "expected resolved version 26.5.2.post2, got ${EXPECTED_VERSION}" >&2
+          if [ "$EXPECTED_VERSION" != "26.5.2.post5" ]; then
+            echo "expected resolved version 26.5.2.post5, got ${EXPECTED_VERSION}" >&2
             exit 1
           fi
           test -x "$CX_PATH"
           test ! -e "$CX_PREFIX"
+
+      - name: Smoke test shell installer
+        shell: bash
+        env:
+          CX_INSTALL_DIR: ${{ runner.temp }}/get-cx
+          CX_NO_BOOTSTRAP: "1"
+          CX_NO_PATH_UPDATE: "1"
+          CX_VERSION: 26.5.2.post5
+        run: |
+          set -euo pipefail
+          sh scripts/get-cx.sh
+          test -x "$CX_INSTALL_DIR/cx"
+
+  windows-installers:
+    name: Windows installers
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Set up cx action
+        id: setup-cx
+        uses: ./.github/actions/setup-cx
+        with:
+          add-to-path: false
+          bootstrap: false
+          version: 26.5.2.post5
+      - name: Check action install
+        shell: pwsh
+        env:
+          CX_PATH: ${{ steps.setup-cx.outputs.cx-path }}
+        run: |
+          if (-not (Test-Path -LiteralPath $Env:CX_PATH)) {
+              throw "cx was not installed at $Env:CX_PATH"
+          }
+      - name: Smoke test PowerShell installer
+        shell: pwsh
+        env:
+          CX_INSTALL_DIR: ${{ runner.temp }}/get-cx
+          CX_NO_BOOTSTRAP: "1"
+          CX_NO_PATH_UPDATE: "1"
+          CX_VERSION: 26.5.2.post5
+        run: |
+          ./scripts/get-cx.ps1
+          if (-not (Test-Path -LiteralPath "$Env:CX_INSTALL_DIR/cx.exe")) {
+              throw "cx.exe was not installed"
+          }
 
   validate:
     name: Validate

--- a/scripts/get-cx.ps1
+++ b/scripts/get-cx.ps1
@@ -187,11 +187,21 @@ try {
 if ($SkipVerify) {
     Write-Warning "Skipping checksum verification because CX_SKIP_VERIFY is set"
 } else {
-    $ChecksumUrl = "${DownloadUrl}.sha256"
+    $ChecksumUrl = ($DownloadUrl -replace '\.exe$', '') + '.sha256'
     $TempSha = [System.IO.Path]::GetTempFileName()
     try {
         Invoke-WebRequest -Uri $ChecksumUrl -OutFile $TempSha -UseBasicParsing
-        $Expected = (Get-Content $TempSha -Raw).Trim().Split()[0]
+        $Expected = Get-Content $TempSha |
+            ForEach-Object {
+                $Parts = $_.Trim() -split '\s+'
+                if ($Parts.Length -ge 2 -and $Parts[1] -eq $AssetName) {
+                    $Parts[0]
+                }
+            } |
+            Select-Object -First 1
+        if (-not $Expected) {
+            throw "Checksum entry not found for $AssetName"
+        }
         $Actual = (Get-FileHash -Path $TempFile -Algorithm SHA256).Hash.ToLower()
 
         if ($Expected -ne $Actual) {

--- a/scripts/get-cx.sh
+++ b/scripts/get-cx.sh
@@ -89,14 +89,19 @@ verify_checksum() {
         return 0
     fi
 
+    _asset_name="${_url##*/}"
     _tmp_sha="$(mktemp "${TMPDIR:-/tmp}/.cx_sha.XXXXXXXX")"
     if ! download "${_url}.sha256" "$_tmp_sha" 2>/dev/null; then
         rm -f "$_tmp_sha"
         err "Checksum file not available: %s.sha256" "$_url"
     fi
 
-    _expected="$(awk '{print $1}' "$_tmp_sha")"
+    _expected="$(awk -v name="$_asset_name" '$2 == name { print $1; exit }' "$_tmp_sha")"
     rm -f "$_tmp_sha"
+
+    if [ -z "$_expected" ]; then
+        err "Checksum entry not found for %s" "$_asset_name"
+    fi
 
     if check_cmd sha256sum; then
         _actual="$(sha256sum "$_file" | awk '{print $1}')"


### PR DESCRIPTION
## Summary

- select the downloaded binary's row from multi-file checksum manifests
- use the suffix-free Windows checksum asset in the PowerShell installer and setup action
- exercise the current release through shell, PowerShell, and Windows action smoke tests
