### PR TITLE
Use changelog for immutable release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,6 +264,11 @@ jobs:
     permissions:
       contents: write # create the immutable GitHub release for this tag
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: refs/tags/${{ needs.validate-release.outputs.tag }}
+          persist-credentials: false
+
       - name: Download cx artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -299,11 +304,23 @@ jobs:
             exit 1
           fi
 
+          notes_file="$RUNNER_TEMP/release-notes.md"
+          awk -v version="$RELEASE_TAG" '
+            $1 == "##" && $2 == version { found = 1; next }
+            found && /^## / { exit }
+            found { print }
+            END { if (!found) exit 1 }
+          ' CHANGELOG.md > "$notes_file"
+          if ! grep -q '[^[:space:]]' "$notes_file"; then
+            echo "No changelog entry found for ${RELEASE_TAG}." >&2
+            exit 1
+          fi
+
           gh release create "$RELEASE_TAG" \
             --draft \
             --verify-tag \
             --title "$RELEASE_TAG" \
-            --notes "conda-express ${RELEASE_TAG}"
+            --notes-file "$notes_file"
 
           cleanup_draft() {
             gh release delete "$RELEASE_TAG" --yes >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

- check out the release tag before creating the draft release
- extract the matching changelog section before the immutable release is published
